### PR TITLE
Fill in predicate annotations

### DIFF
--- a/Annotation/alternative_golden_set.json
+++ b/Annotation/alternative_golden_set.json
@@ -6,8 +6,8 @@
                 "predicate": [
                     {
                         "str": "analyzes",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "analyze",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -23,8 +23,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -40,8 +40,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -57,8 +57,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -73,9 +73,14 @@
             {
                 "predicate": [
                     {
-                        "str": "based on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "based",
+                        "lemma": "base",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -91,8 +96,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -108,8 +113,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -125,8 +130,8 @@
                 "predicate": [
                     {
                         "str": "knowing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -142,8 +147,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -159,8 +164,8 @@
                 "predicate": [
                     {
                         "str": "defined",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "define",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -176,8 +181,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -193,8 +198,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -210,8 +215,8 @@
                 "predicate": [
                     {
                         "str": "illustrated",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "illustrate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -226,9 +231,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is almost confusing",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "confusing",
+                        "lemma": "confusing",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -244,8 +254,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -260,9 +270,14 @@
             {
                 "predicate": [
                     {
-                        "str": "fighting about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "fighting",
+                        "lemma": "fight",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -277,9 +292,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is irrelevant",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "irrelevant",
+                        "lemma": "irrelevant",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -292,13 +312,7 @@
         "sentence": "It doesn\u2019t matter whether its work, family, or friends, good morals will get you a long way with people, and they will respect you for it!",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "matter",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether its work, family, or friends",
                 "embedded clauses": []
@@ -312,8 +326,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -329,8 +343,8 @@
                 "predicate": [
                     {
                         "str": "told",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -343,13 +357,7 @@
         "sentence": "So as long as everyone would be exposed to STEM and be able to choose it as a career to pursue without pressure to not do so, it doens't matter to me whether it's 50/50, 60/40 or 70/30.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "matter",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether it's 50/50, 60/40 or 70/30",
                 "embedded clauses": []
@@ -363,8 +371,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -379,9 +387,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is certain",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "certain",
+                        "lemma": "certain",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -397,8 +410,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -413,9 +426,14 @@
             {
                 "predicate": [
                     {
-                        "str": "remains ambiguous",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "remains",
+                        "lemma": "remain",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "ambiguous",
+                        "lemma": "ambiguous",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -428,13 +446,7 @@
         "sentence": "He wonders whether reality is a dream or dreams reality.\u201d This isn\u2019t ordinary narration, which conveys information the film for one reason or other can\u2019t dramatize.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "wonders",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether reality is a dream or dreams reality",
                 "embedded clauses": []
@@ -448,8 +460,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -464,9 +476,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depending on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depending",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -476,9 +493,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depending on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depending",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -494,8 +516,8 @@
                 "predicate": [
                     {
                         "str": "reveal",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reveal",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -510,9 +532,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depending on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depending",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -527,9 +554,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depends on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depends",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -544,9 +576,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depend on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depend",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -562,8 +599,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -578,9 +615,14 @@
             {
                 "predicate": [
                     {
-                        "str": "be random",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "be",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "random",
+                        "lemma": "random",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -596,8 +638,8 @@
                 "predicate": [
                     {
                         "str": "wonder",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -612,9 +654,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is unclear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "unclear",
+                        "lemma": "unclear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -630,8 +677,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -647,8 +694,8 @@
                 "predicate": [
                     {
                         "str": "wonder",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -664,8 +711,8 @@
                 "predicate": [
                     {
                         "str": "known",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -680,9 +727,14 @@
             {
                 "predicate": [
                     {
-                        "str": "be irrelevant",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "be",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "irrelevant",
+                        "lemma": "irrelevant",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -695,13 +747,7 @@
         "sentence": "(And whether those similarities are due to nature or nurture, does it really matter?)",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "matter",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether those similarities are due to nature or nurture",
                 "embedded clauses": []
@@ -715,8 +761,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -729,13 +775,7 @@
         "sentence": "Here, Greenwood succinctly counters polarised ways of thinking in terms of \"primitive\" and \"modern,\" preferring instead to judge whether the significance of important past episodes \"represented an advance or regression in the general development of psychological theory and practice\" (4).",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "judge",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether the significance of important past episodes \"represented an advance or regression in the general development of psychological theory and practice\" (4)",
                 "embedded clauses": []
@@ -749,8 +789,8 @@
                 "predicate": [
                     {
                         "str": "choosing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "choose",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -763,13 +803,7 @@
         "sentence": "The point is that this makes it possible to readily construct a relatively simple reader which can discern (by determining the length of the respective distance a or b) whether the carrier body 10 has been inserted with the edge 13 leading or with the edge 12 leading.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "discern",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether the carrier body 10 has been inserted with the edge 13 leading or with the edge 12 leading",
                 "embedded clauses": []
@@ -782,9 +816,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is immaterial",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "immaterial",
+                        "lemma": "immaterial",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -797,13 +836,7 @@
         "sentence": "That said, it matters little whether I am over-eating or under-eating.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "matters",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether I am over-eating or under-eating",
                 "embedded clauses": []
@@ -814,13 +847,7 @@
         "sentence": "Wonder whether during this thirty or forty year period of the low-fat dogma, whether breastfeeding rates went up or down.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "Wonder",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether during this thirty or forty year period of the low-fat dogma, whether breastfeeding rates went up or down",
                 "embedded clauses": []
@@ -833,9 +860,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is not quite clear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "clear",
+                        "lemma": "clear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -850,9 +882,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depending on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depending",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -867,9 +904,14 @@
             {
                 "predicate": [
                     {
-                        "str": "remains unclear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "remains",
+                        "lemma": "remain",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "unclear",
+                        "lemma": "unclear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "alternative",
@@ -885,8 +927,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -902,8 +944,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -916,13 +958,7 @@
         "sentence": "The library should not have to deal with training staff to discern whether patrons are students or adults who look like students.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "discern",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether patrons are students or adults who look like students",
                 "embedded clauses": []
@@ -933,13 +969,7 @@
         "sentence": "It doesn\u0092t even matter whether any given piece of your writing is carefully polished already or just a new idea you dashed off on the train today \u0096 as long as it\u0092s readable and well enough developed that a critique might be helpful.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "matter",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether any given piece of your writing is carefully polished already or just a new idea you dashed off on the train today",
                 "embedded clauses": []
@@ -953,8 +983,8 @@
                 "predicate": [
                     {
                         "str": "decided",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -969,9 +999,9 @@
             {
                 "predicate": [
                     {
-                        "str": "speak to",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "speak",
+                        "lemma": "speak",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -987,8 +1017,8 @@
                 "predicate": [
                     {
                         "str": "conclude",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "conclude",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1004,8 +1034,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1021,8 +1051,8 @@
                 "predicate": [
                     {
                         "str": "identify",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "identify",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1037,9 +1067,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depending on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depending",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -1054,9 +1089,14 @@
             {
                 "predicate": [
                     {
-                        "str": "debating over",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "debating",
+                        "lemma": "debate",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "over",
+                        "lemma": "over",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -1067,8 +1107,8 @@
                 "predicate": [
                     {
                         "str": "decided",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1084,8 +1124,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1101,8 +1141,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1118,8 +1158,8 @@
                 "predicate": [
                     {
                         "str": "recall",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "recall",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1134,9 +1174,14 @@
             {
                 "predicate": [
                     {
-                        "str": "distinguished by",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "distinguished",
+                        "lemma": "distinguish",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "by",
+                        "lemma": "by",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -1149,13 +1194,7 @@
         "sentence": "This concerns whether they fall into tax class 1 (mostly applicable to unmarried residents) or tax class 2 (people who are married or in civil partnerships).",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "concerns",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether they fall into tax class 1 (mostly applicable to unmarried residents) or tax class 2 (people who are married or in civil partnerships)",
                 "embedded clauses": []
@@ -1169,8 +1208,8 @@
                 "predicate": [
                     {
                         "str": "considers",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "consider",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1186,8 +1225,8 @@
                 "predicate": [
                     {
                         "str": "check",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "check",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1203,8 +1242,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1219,9 +1258,14 @@
             {
                 "predicate": [
                     {
-                        "str": "undecided on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "undecided",
+                        "lemma": "undecided",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -1237,26 +1281,37 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
                 "clause": "whether to require a full formal filing or determine that no further action is necessary",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "determine",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that no further action is necessary",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "decide",
+                            "lemma": "decide",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "alternative",
+                    "clause": "whether to require a full formal filing or determine that no further action is necessary",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "determine",
+                                    "lemma": "determine",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that no further action is necessary",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -1267,8 +1322,8 @@
                 "predicate": [
                     {
                         "str": "predict",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "predict",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1284,8 +1339,8 @@
                 "predicate": [
                     {
                         "str": "clarify",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "clarify",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1301,8 +1356,8 @@
                 "predicate": [
                     {
                         "str": "Deciding",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1318,8 +1373,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1334,9 +1389,14 @@
             {
                 "predicate": [
                     {
-                        "str": "find out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "find",
+                        "lemma": "find",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -1351,9 +1411,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depends on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depends",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -1369,8 +1434,8 @@
                 "predicate": [
                     {
                         "str": "check",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "check",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1386,8 +1451,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1403,8 +1468,8 @@
                 "predicate": [
                     {
                         "str": "guess",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "guess",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1420,8 +1485,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1434,13 +1499,7 @@
         "sentence": "You can\u0092t easily configure whether you want the video to be oriented horizontally (landscape) or vertically (portrait).",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "configure",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "alternative",
                 "clause": "whether you want the video to be oriented horizontally (landscape) or vertically (portrait)",
                 "embedded clauses": []
@@ -1454,8 +1513,8 @@
                 "predicate": [
                     {
                         "str": "includes",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "include",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",
@@ -1470,9 +1529,14 @@
             {
                 "predicate": [
                     {
-                        "str": "gone back and forth on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "gone",
+                        "lemma": "go",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "alternative",
@@ -1488,8 +1552,8 @@
                 "predicate": [
                     {
                         "str": "make",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "make",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "alternative",

--- a/Annotation/constituent_golden_set.json
+++ b/Annotation/constituent_golden_set.json
@@ -5,9 +5,14 @@
             {
                 "predicate": [
                     {
-                        "str": "figure out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "figure",
+                        "lemma": "figure",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -23,8 +28,8 @@
                 "predicate": [
                     {
                         "str": "get",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "get",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -40,8 +45,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -57,8 +62,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -74,8 +79,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -88,13 +93,7 @@
         "sentence": "Query why, exactly, we allow a tax deduction for charitable giving.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "query",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "constituent",
                 "clause": "why, exactly, we allow a tax deduction for charitable giving",
                 "embedded clauses": []
@@ -108,8 +107,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -125,8 +124,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -141,9 +140,14 @@
             {
                 "predicate": [
                     {
-                        "str": "apologize for",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "apologize",
+                        "lemma": "apologize",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "for",
+                        "lemma": "for",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -158,9 +162,14 @@
             {
                 "predicate": [
                     {
-                        "str": "Find out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "Find",
+                        "lemma": "find",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -176,8 +185,8 @@
                 "predicate": [
                     {
                         "str": "demonstrates",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "demonstrate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -193,8 +202,8 @@
                 "predicate": [
                     {
                         "str": "wonder",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -205,8 +214,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -222,8 +231,8 @@
                 "predicate": [
                     {
                         "str": "seen",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -239,8 +248,8 @@
                 "predicate": [
                     {
                         "str": "seen",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -251,8 +260,8 @@
                 "predicate": [
                     {
                         "str": "seen",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -268,8 +277,8 @@
                 "predicate": [
                     {
                         "str": "understood",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -285,8 +294,8 @@
                 "predicate": [
                     {
                         "str": "explains",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -302,8 +311,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -319,8 +328,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -336,8 +345,8 @@
                 "predicate": [
                     {
                         "str": "explaining",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -348,8 +357,8 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -365,8 +374,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -381,9 +390,14 @@
             {
                 "predicate": [
                     {
-                        "str": "'s not too clear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "'s",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "clear",
+                        "lemma": "clear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "constituent",
@@ -399,8 +413,8 @@
                 "predicate": [
                     {
                         "str": "wonder",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -416,8 +430,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -428,8 +442,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -440,8 +454,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -452,8 +466,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -464,8 +478,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -480,9 +494,14 @@
             {
                 "predicate": [
                     {
-                        "str": "asked about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "asked",
+                        "lemma": "ask",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -498,8 +517,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -515,8 +534,8 @@
                 "predicate": [
                     {
                         "str": "explain",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -532,8 +551,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -549,8 +568,8 @@
                 "predicate": [
                     {
                         "str": "hearing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "hear",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -566,8 +585,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -583,8 +602,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -600,8 +619,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -616,9 +635,14 @@
             {
                 "predicate": [
                     {
-                        "str": "hear of",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "hear",
+                        "lemma": "hear",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "of",
+                        "lemma": "of",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -634,8 +658,8 @@
                 "predicate": [
                     {
                         "str": "wondered",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -646,8 +670,8 @@
                 "predicate": [
                     {
                         "str": "wondered",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -663,26 +687,47 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
                 "clause": "how real and honest they are about how they could forgive",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "real and honest they are about",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "constituent",
-                        "clause": "how they could forgive",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "see",
+                            "lemma": "see",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "constituent",
+                    "clause": "how real and honest they are about how they could forgive",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "real",
+                                    "lemma": "real",
+                                    "POS": "ADJ"
+                                },
+                                {
+                                    "str": "honest",
+                                    "lemma": "honest",
+                                    "POS": "ADJ"
+                                },
+                                {
+                                    "str": "are",
+                                    "lemma": "be",
+                                    "POS": "AUX"
+                                }
+                            ],
+                            "type": "constituent",
+                            "clause": "how they could forgive",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -693,8 +738,8 @@
                 "predicate": [
                     {
                         "str": "demonstrates",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "demonstrate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -710,8 +755,8 @@
                 "predicate": [
                     {
                         "str": "reflect",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reflect",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -722,8 +767,8 @@
                 "predicate": [
                     {
                         "str": "reflect",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reflect",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -734,8 +779,8 @@
                 "predicate": [
                     {
                         "str": "reflect",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reflect",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -750,9 +795,9 @@
             {
                 "predicate": [
                     {
-                        "str": "is not known",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "known",
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -765,13 +810,7 @@
         "sentence": "Keith Carr, who has now retired, remembers when he went to treat him in 2013.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "remembers",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "constituent",
                 "clause": "when he went to treat him in 2013",
                 "embedded clauses": []
@@ -785,8 +824,8 @@
                 "predicate": [
                     {
                         "str": "show",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "show",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -802,8 +841,8 @@
                 "predicate": [
                     {
                         "str": "says",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -814,8 +853,8 @@
                 "predicate": [
                     {
                         "str": "says",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -831,8 +870,8 @@
                 "predicate": [
                     {
                         "str": "explained",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -847,9 +886,9 @@
             {
                 "predicate": [
                     {
-                        "str": "comment on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -865,8 +904,8 @@
                 "predicate": [
                     {
                         "str": "tweeted",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tweet",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -881,9 +920,9 @@
             {
                 "predicate": [
                     {
-                        "str": "is not known",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "known",
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -899,8 +938,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -916,8 +955,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -928,8 +967,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -945,8 +984,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -962,8 +1001,8 @@
                 "predicate": [
                     {
                         "str": "knows",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -979,8 +1018,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -996,8 +1035,8 @@
                 "predicate": [
                     {
                         "str": "explains",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1012,9 +1051,14 @@
             {
                 "predicate": [
                     {
-                        "str": "remains unclear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "remains",
+                        "lemma": "remain",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "unclear",
+                        "lemma": "unclear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "constituent",
@@ -1030,8 +1074,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1042,8 +1086,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1059,26 +1103,37 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
                 "clause": "how his slightly left-of-center orientation (or left-of-right, as the case may be) means that he is a slightly controversial figure in some circles today",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "means",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that he is a slightly controversial figure in some circles today",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "see",
+                            "lemma": "see",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "constituent",
+                    "clause": "how his slightly left-of-center orientation (or left-of-right, as the case may be) means that he is a slightly controversial figure in some circles today",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "means",
+                                    "lemma": "mean",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that he is a slightly controversial figure in some circles today",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -1089,8 +1144,8 @@
                 "predicate": [
                     {
                         "str": "discuss",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1106,8 +1161,8 @@
                 "predicate": [
                     {
                         "str": "relates",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "relate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1122,9 +1177,14 @@
             {
                 "predicate": [
                     {
-                        "str": "reflect on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "reflect",
+                        "lemma": "reflect",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1139,9 +1199,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is wonderful",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "wonderful",
+                        "lemma": "wonderful",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "constituent",
@@ -1157,8 +1222,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1174,8 +1239,8 @@
                 "predicate": [
                     {
                         "str": "imagine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "imagine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1191,26 +1256,37 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "You do not know what I have to go through",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "know",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "constituent",
-                        "clause": "what I have to go through",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "tell",
+                            "lemma": "tell",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "You do not know what I have to go through",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "know",
+                                    "lemma": "know",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "constituent",
+                            "clause": "what I have to go through",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -1221,8 +1297,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1238,8 +1314,8 @@
                 "predicate": [
                     {
                         "str": "investigate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "investigate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1250,8 +1326,8 @@
                 "predicate": [
                     {
                         "str": "researching",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "research",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1267,8 +1343,8 @@
                 "predicate": [
                     {
                         "str": "wondering",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1284,8 +1360,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1301,8 +1377,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1318,8 +1394,8 @@
                 "predicate": [
                     {
                         "str": "decides",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1335,8 +1411,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1352,8 +1428,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1366,13 +1442,7 @@
         "sentence": "Each isomer can be synthesized using the trans effect to control which isomer is produced.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "control",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "constituent",
                 "clause": "which isomer is produced",
                 "embedded clauses": []
@@ -1386,8 +1456,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1402,9 +1472,14 @@
             {
                 "predicate": [
                     {
-                        "str": "think of",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "think",
+                        "lemma": "think",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "of",
+                        "lemma": "of",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1420,8 +1495,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1431,9 +1506,14 @@
             {
                 "predicate": [
                     {
-                        "str": "talk about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "talk",
+                        "lemma": "talk",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1449,8 +1529,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1466,8 +1546,8 @@
                 "predicate": [
                     {
                         "str": "realized",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "realize",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1483,8 +1563,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1500,8 +1580,8 @@
                 "predicate": [
                     {
                         "str": "learned",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "learn",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1517,8 +1597,8 @@
                 "predicate": [
                     {
                         "str": "probe",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "probe",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1531,13 +1611,7 @@
         "sentence": "How mantle flows on Earth might control why there is life on our planet but not on other planets, such as Venus, which has a similar size and location in the solar system to Earth, but likely has a very different style of mantle flow.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "control",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "constituent",
                 "clause": "why there is life on our planet but not on other planets, such as Venus, which has a similar size and location in the solar system to Earth, but likely has a very different style of mantle flow",
                 "embedded clauses": []
@@ -1551,8 +1625,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1563,8 +1637,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1580,8 +1654,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1597,8 +1671,8 @@
                 "predicate": [
                     {
                         "str": "remember",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "remember",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1609,8 +1683,8 @@
                 "predicate": [
                     {
                         "str": "remember",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "remember",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1626,8 +1700,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1638,8 +1712,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1654,9 +1728,9 @@
             {
                 "predicate": [
                     {
-                        "str": "flesh out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1671,9 +1745,14 @@
             {
                 "predicate": [
                     {
-                        "str": "focuses mainly on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "focuses",
+                        "lemma": "focus",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1683,24 +1762,22 @@
             {
                 "predicate": [
                     {
-                        "str": "focuses mainly on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "focuses",
+                        "lemma": "focus",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
                 "clause": "what she\u2019s going to do",
                 "embedded clauses": []
-            }
-            ,
+            },
             {
-                "predicate": [
-                    {
-                        "str": "less so on",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "constituent",
                 "clause": "what happens to her physically",
                 "embedded clauses": []
@@ -1713,9 +1790,14 @@
             {
                 "predicate": [
                     {
-                        "str": "pestering Megan about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "pestering",
+                        "lemma": "pester",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1730,9 +1812,9 @@
             {
                 "predicate": [
                     {
-                        "str": "explained bout",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "explained",
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1742,9 +1824,9 @@
             {
                 "predicate": [
                     {
-                        "str": "explained bout",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "explained",
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1759,9 +1841,14 @@
             {
                 "predicate": [
                     {
-                        "str": "think about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "think",
+                        "lemma": "think",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1776,9 +1863,19 @@
             {
                 "predicate": [
                     {
-                        "str": "'m not sure",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "'",
+                        "lemma": "'",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "m",
+                        "lemma": "m",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "sure",
+                        "lemma": "sure",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "constituent",
@@ -1788,9 +1885,24 @@
             {
                 "predicate": [
                     {
-                        "str": "'m very aware of",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "'",
+                        "lemma": "'",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "m",
+                        "lemma": "m",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "aware",
+                        "lemma": "aware",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "of",
+                        "lemma": "of",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1806,8 +1918,8 @@
                 "predicate": [
                     {
                         "str": "realize",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "realize",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1823,8 +1935,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1840,8 +1952,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1857,8 +1969,8 @@
                 "predicate": [
                     {
                         "str": "accepting",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "accept",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1869,8 +1981,8 @@
                 "predicate": [
                     {
                         "str": "accepting",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "accept",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1886,8 +1998,8 @@
                 "predicate": [
                     {
                         "str": "distinguish",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "distinguish",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1902,9 +2014,14 @@
             {
                 "predicate": [
                     {
-                        "str": "find out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "find",
+                        "lemma": "find",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1915,8 +2032,8 @@
                 "predicate": [
                     {
                         "str": "estimate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "estimate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1931,9 +2048,14 @@
             {
                 "predicate": [
                     {
-                        "str": "mused about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "mused",
+                        "lemma": "muse",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1943,9 +2065,14 @@
             {
                 "predicate": [
                     {
-                        "str": "mused about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "mused",
+                        "lemma": "muse",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -1961,8 +2088,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1978,8 +2105,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1994,9 +2121,14 @@
             {
                 "predicate": [
                     {
-                        "str": "figure out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "figure",
+                        "lemma": "figure",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -2012,8 +2144,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2029,8 +2161,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2046,8 +2178,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2058,8 +2190,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2075,8 +2207,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2092,8 +2224,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2109,8 +2241,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2126,8 +2258,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2143,8 +2275,8 @@
                 "predicate": [
                     {
                         "str": "wonder",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2160,8 +2292,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2172,8 +2304,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2189,8 +2321,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2206,8 +2338,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2223,8 +2355,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2235,8 +2367,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2252,8 +2384,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2268,9 +2400,14 @@
             {
                 "predicate": [
                     {
-                        "str": "think about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "think",
+                        "lemma": "think",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -2286,8 +2423,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2298,8 +2435,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2315,26 +2452,37 @@
                 "predicate": [
                     {
                         "str": "wondered",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
                 "clause": "what it is like to hear from your loved one that they have been diagnosed with cancer",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "hear",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that they have been diagnosed with cancer",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "wondered",
+                            "lemma": "wonder",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "constituent",
+                    "clause": "what it is like to hear from your loved one that they have been diagnosed with cancer",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "hear",
+                                    "lemma": "hear",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that they have been diagnosed with cancer",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -2345,8 +2493,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2362,8 +2510,8 @@
                 "predicate": [
                     {
                         "str": "deciding",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2379,8 +2527,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -2396,8 +2544,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",

--- a/Annotation/declarative_golden_set.json
+++ b/Annotation/declarative_golden_set.json
@@ -3,13 +3,7 @@
         "sentence": "Luminosity Gaming may be about to recruit a new CS:GO player, as VPEsports reports that Ricardo 'boltz' Prass is set to rejoin the side to replace Gustavo 'yeL' Knittel.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "reports",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "declarative",
                 "clause": "that Ricardo 'boltz' Prass is set to rejoin the side to replace Gustavo 'yeL' Knittel",
                 "embedded clauses": []
@@ -23,8 +17,8 @@
                 "predicate": [
                     {
                         "str": "believe",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "believe",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -40,8 +34,8 @@
                 "predicate": [
                     {
                         "str": "find",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "find",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -57,8 +51,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -74,8 +68,8 @@
                 "predicate": [
                     {
                         "str": "decided",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -91,8 +85,8 @@
                 "predicate": [
                     {
                         "str": "felt",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "feel",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -108,8 +102,8 @@
                 "predicate": [
                     {
                         "str": "praying",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "pray",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -120,8 +114,8 @@
                 "predicate": [
                     {
                         "str": "praying",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "pray",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -137,8 +131,8 @@
                 "predicate": [
                     {
                         "str": "mention",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "mention",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -154,8 +148,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -171,8 +165,8 @@
                 "predicate": [
                     {
                         "str": "realized",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "realize",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -188,8 +182,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -200,8 +194,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -217,8 +211,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -234,8 +228,8 @@
                 "predicate": [
                     {
                         "str": "thinking",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -251,8 +245,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -268,8 +262,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -285,8 +279,8 @@
                 "predicate": [
                     {
                         "str": "argue",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "argue",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -302,8 +296,8 @@
                 "predicate": [
                     {
                         "str": "believe",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "believe",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -319,8 +313,8 @@
                 "predicate": [
                     {
                         "str": "deny",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "deny",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -336,8 +330,8 @@
                 "predicate": [
                     {
                         "str": "holds",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "hold",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -353,8 +347,8 @@
                 "predicate": [
                     {
                         "str": "admit",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "admit",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -370,8 +364,8 @@
                 "predicate": [
                     {
                         "str": "indicate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "indicate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -387,8 +381,8 @@
                 "predicate": [
                     {
                         "str": "admit",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "admit",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -404,26 +398,37 @@
                 "predicate": [
                     {
                         "str": "write",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "write",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "\u201cOften, we learn that something is precious only when we see it in the light of someone\u2019s love\u201d",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "learn",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that something is precious",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "write",
+                            "lemma": "write",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "\u201cOften, we learn that something is precious only when we see it in the light of someone\u2019s love\u201d",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "learn",
+                                    "lemma": "learn",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that something is precious",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -434,8 +439,8 @@
                 "predicate": [
                     {
                         "str": "seeing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -451,8 +456,8 @@
                 "predicate": [
                     {
                         "str": "saying",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -463,8 +468,8 @@
                 "predicate": [
                     {
                         "str": "signaling",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "signal",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -480,8 +485,8 @@
                 "predicate": [
                     {
                         "str": "revealed",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reveal",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -492,8 +497,8 @@
                 "predicate": [
                     {
                         "str": "announced",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "announce",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -509,8 +514,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -526,8 +531,8 @@
                 "predicate": [
                     {
                         "str": "mention",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "mention",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -543,8 +548,8 @@
                 "predicate": [
                     {
                         "str": "suggesting",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "suggest",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -560,8 +565,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -577,8 +582,8 @@
                 "predicate": [
                     {
                         "str": "fear",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "fear",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -594,26 +599,42 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "I was so stunned that it was meant for him that I didn\u2019t get it at first, until my friend hit me hard in the leg and she said to me \u201cDid YOU HEAR THAT??\u201d And I look at C\u2019s dad and he\u2019s saying the same",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "was so stunned",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that it was meant for him",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "think",
+                            "lemma": "think",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "I was so stunned that it was meant for him that I didn\u2019t get it at first, until my friend hit me hard in the leg and she said to me \u201cDid YOU HEAR THAT??\u201d And I look at C\u2019s dad and he\u2019s saying the same",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "was",
+                                    "lemma": "be",
+                                    "POS": "AUX"
+                                },
+                                {
+                                    "str": "stunned",
+                                    "lemma": "stunned",
+                                    "POS": "ADJ"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that it was meant for him",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -624,26 +645,37 @@
                 "predicate": [
                     {
                         "str": "understands",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "that he can do so much more then he thought he could",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "thought",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "he could",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "understands",
+                            "lemma": "understand",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "that he can do so much more then he thought he could",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "thought",
+                                    "lemma": "think",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "he could",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -654,8 +686,8 @@
                 "predicate": [
                     {
                         "str": "told",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -671,8 +703,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -688,8 +720,8 @@
                 "predicate": [
                     {
                         "str": "guarantee",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "guarantee",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -705,8 +737,8 @@
                 "predicate": [
                     {
                         "str": "realize",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "realize",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -722,8 +754,8 @@
                 "predicate": [
                     {
                         "str": "reiterate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reiterate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -739,8 +771,8 @@
                 "predicate": [
                     {
                         "str": "wish",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wish",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -756,8 +788,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -773,8 +805,8 @@
                 "predicate": [
                     {
                         "str": "says",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -790,8 +822,8 @@
                 "predicate": [
                     {
                         "str": "understood",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -807,8 +839,8 @@
                 "predicate": [
                     {
                         "str": "knows",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -824,8 +856,8 @@
                 "predicate": [
                     {
                         "str": "guess",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "guess",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -841,8 +873,8 @@
                 "predicate": [
                     {
                         "str": "says",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -858,8 +890,8 @@
                 "predicate": [
                     {
                         "str": "told",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -875,26 +907,37 @@
                 "predicate": [
                     {
                         "str": "says",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "she hopes the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "hopes",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "says",
+                            "lemma": "say",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "she hopes the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "hopes",
+                                    "lemma": "hope",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -905,8 +948,8 @@
                 "predicate": [
                     {
                         "str": "says",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -922,8 +965,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -934,8 +977,8 @@
                 "predicate": [
                     {
                         "str": "means",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "mean",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -951,8 +994,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -963,8 +1006,8 @@
                 "predicate": [
                     {
                         "str": "realize",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "realize",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -980,8 +1023,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -997,8 +1040,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1014,8 +1057,8 @@
                 "predicate": [
                     {
                         "str": "noticed",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "notice",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1031,8 +1074,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1048,8 +1091,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1062,13 +1105,7 @@
         "sentence": "NationalLedger.com reports that Christina Aguilera risked re-igniting her feud with Britney Spears by a comment made on her wedding day",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "reports",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "declarative",
                 "clause": "that Christina Aguilera risked re-igniting her feud with Britney Spears by a comment made on her wedding day",
                 "embedded clauses": []
@@ -1082,8 +1119,8 @@
                 "predicate": [
                     {
                         "str": "denies",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "deny",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1099,8 +1136,8 @@
                 "predicate": [
                     {
                         "str": "argues",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "argue",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1116,8 +1153,8 @@
                 "predicate": [
                     {
                         "str": "appreciate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "appreciate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1133,8 +1170,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1150,8 +1187,8 @@
                 "predicate": [
                     {
                         "str": "reported",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "report",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1167,8 +1204,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1184,33 +1221,44 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "they thought it was a virus",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "thought",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "it was a virus",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "said",
+                            "lemma": "say",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "they thought it was a virus",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "thought",
+                                    "lemma": "think",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "it was a virus",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             },
             {
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1226,8 +1274,8 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1243,8 +1291,8 @@
                 "predicate": [
                     {
                         "str": "told",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1260,8 +1308,8 @@
                 "predicate": [
                     {
                         "str": "learned",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "learn",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1277,8 +1325,8 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1293,9 +1341,14 @@
             {
                 "predicate": [
                     {
-                        "str": "find out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "find",
+                        "lemma": "find",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "declarative",
@@ -1311,8 +1364,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1328,8 +1381,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1345,8 +1398,8 @@
                 "predicate": [
                     {
                         "str": "ensure",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ensure",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1362,8 +1415,8 @@
                 "predicate": [
                     {
                         "str": "declaring",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "declare",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1379,8 +1432,8 @@
                 "predicate": [
                     {
                         "str": "ensure",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ensure",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1396,8 +1449,8 @@
                 "predicate": [
                     {
                         "str": "estimates",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "estimate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1413,8 +1466,8 @@
                 "predicate": [
                     {
                         "str": "told",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1430,8 +1483,8 @@
                 "predicate": [
                     {
                         "str": "saying",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1442,8 +1495,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1459,8 +1512,8 @@
                 "predicate": [
                     {
                         "str": "telling",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1476,8 +1529,8 @@
                 "predicate": [
                     {
                         "str": "believes",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "believe",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1493,8 +1546,8 @@
                 "predicate": [
                     {
                         "str": "claims",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "claim",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1510,8 +1563,8 @@
                 "predicate": [
                     {
                         "str": "agreed",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "agree",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1527,26 +1580,37 @@
                 "predicate": [
                     {
                         "str": "held",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "hold",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "that Abdulkadir failed to show that the FBI\u2019s confidential informant was material to his defense",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "show",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that the FBI\u2019s confidential informant was material to his defense",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "held",
+                            "lemma": "hold",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "that Abdulkadir failed to show that the FBI\u2019s confidential informant was material to his defense",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "show",
+                                    "lemma": "show",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that the FBI\u2019s confidential informant was material to his defense",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -1557,8 +1621,8 @@
                 "predicate": [
                     {
                         "str": "noted",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "note",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1574,8 +1638,8 @@
                 "predicate": [
                     {
                         "str": "reveals",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reveal",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1586,8 +1650,8 @@
                 "predicate": [
                     {
                         "str": "reveals",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reveal",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1603,8 +1667,8 @@
                 "predicate": [
                     {
                         "str": "ensure",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ensure",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1620,8 +1684,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1637,8 +1701,8 @@
                 "predicate": [
                     {
                         "str": "speculating",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "speculate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1654,8 +1718,8 @@
                 "predicate": [
                     {
                         "str": "argue",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "argue",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1666,8 +1730,8 @@
                 "predicate": [
                     {
                         "str": "feel",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "feel",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1680,13 +1744,7 @@
         "sentence": "This is to inform you that you have been selected for a cash prize of \u00a3850,000.00 (Eight hundred and fifty thousand Great British Pounds) from the BMW AUTOMOBILE GROUP e-LOTTERY BONANZA International programs held TODAY Teusday the 6th of MARCH 2007, here in London United Kingdom.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "inform",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "declarative",
                 "clause": "that you have been selected for a cash prize of \u00a3850,000.00 (Eight hundred and fifty thousand Great British Pounds) from the BMW AUTOMOBILE GROUP e-LOTTERY BONANZA International programs held TODAY Teusday the 6th of MARCH 2007, here in London United Kingdom",
                 "embedded clauses": []
@@ -1700,8 +1758,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1717,8 +1775,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1734,8 +1792,8 @@
                 "predicate": [
                     {
                         "str": "revealed",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reveal",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1751,8 +1809,8 @@
                 "predicate": [
                     {
                         "str": "demonstrated",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "demonstrate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1768,26 +1826,42 @@
                 "predicate": [
                     {
                         "str": "admits",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "admit",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "he was puzzled by why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "was puzzled by",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "constituent",
-                        "clause": "why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "admits",
+                            "lemma": "admit",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "he was puzzled by why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "puzzled",
+                                    "lemma": "puzzle",
+                                    "POS": "VERB"
+                                },
+                                {
+                                    "str": "by",
+                                    "lemma": "by",
+                                    "POS": "ADP"
+                                }
+                            ],
+                            "type": "constituent",
+                            "clause": "why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -1798,8 +1872,8 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1815,8 +1889,8 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1832,8 +1906,8 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1849,8 +1923,8 @@
                 "predicate": [
                     {
                         "str": "reminded",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "remind",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1866,8 +1940,8 @@
                 "predicate": [
                     {
                         "str": "admitting",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "admit",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1883,8 +1957,8 @@
                 "predicate": [
                     {
                         "str": "ensured",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ensure",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1900,8 +1974,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1917,8 +1991,8 @@
                 "predicate": [
                     {
                         "str": "believe",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "believe",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1934,8 +2008,8 @@
                 "predicate": [
                     {
                         "str": "thought",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1951,8 +2025,8 @@
                 "predicate": [
                     {
                         "str": "said",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1967,9 +2041,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is aware",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "aware",
+                        "lemma": "aware",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "declarative",
@@ -1985,8 +2064,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -2002,8 +2081,8 @@
                 "predicate": [
                     {
                         "str": "thought",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -2019,8 +2098,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -2036,8 +2115,8 @@
                 "predicate": [
                     {
                         "str": "note",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "note",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -2053,8 +2132,8 @@
                 "predicate": [
                     {
                         "str": "confirm",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "confirm",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -2067,13 +2146,7 @@
         "sentence": "I hope my start a blog tutorial has been of help and I look forward to hear your input and also read your new, beautiful blogs",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "hope",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "declarative",
                 "clause": "my start a blog tutorial has been of help",
                 "embedded clauses": []
@@ -2084,13 +2157,7 @@
         "sentence": "Irving Azoff Claims YouTube \"Pirates\" Are \"Really Evil\"",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "Claims",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "declarative",
                 "clause": "YouTube \"Pirates\" Are \"Really Evil\"",
                 "embedded clauses": []
@@ -2104,8 +2171,8 @@
                 "predicate": [
                     {
                         "str": "explain",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "explain",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -2121,8 +2188,8 @@
                 "predicate": [
                     {
                         "str": "announced",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "announce",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",

--- a/Annotation/expand_predicate_annotations.py
+++ b/Annotation/expand_predicate_annotations.py
@@ -1,0 +1,68 @@
+import spacy
+import json
+import os
+import nested_lookup
+
+nlp = spacy.load("en_core_web_sm")
+
+
+#extract the string, lemma, and pos tags for the relevant tokens in the predicate
+def get_pred_info(pred_str):
+    final_pred = []
+    doc = nlp(pred_str)
+
+    #information for each token, from spacy
+    token_annots = [{'str': token.text, 'lemma': token.lemma_, 'POS': token.pos_} for token in doc]
+    pos_tags = [token.pos_ for token in doc]
+
+    #we only want verbs, prepositions, adjectives, and (iff the predicate contains an adjective) auxiliaries
+    for token in token_annots:
+        pos = token['POS']
+        if pos in ['VERB', 'ADP', 'ADJ'] or ("ADJ" in pos_tags and pos == "AUX"):
+            final_pred.append(token)
+
+    return final_pred
+
+
+#apply get_pred_info function to an embedded clause dict
+def fill_pred_info(embedded):
+    new_emb = embedded
+    full_pred = get_pred_info(embedded['predicate'][0]['str'])
+    new_emb['predicate'] = full_pred
+    return new_emb
+
+
+#apply get_pred_info function to an embedded clause dict for nested clauses
+def nested_fill(embedded):
+    new_emb = []
+    for n in embedded: 
+        new_n = n
+        full_pred = get_pred_info(n['predicate'][0]['str'])
+        new_n['predicate'] = full_pred
+        new_emb.append(new_n)
+    return new_emb
+
+
+#open and modify the annotated json file to include all relevant predicate info
+def predicate_expander(filepath):
+    with open(filepath, mode="r", encoding="utf-8") as f:
+        data = json.load(f)
+
+        #iterate through sentences
+        for key in data.keys():
+            embedded_clauses = data[key]['embedded clauses']
+
+            #iterate recursively through all embedded clauses in the sentence
+            for i, ec in enumerate(embedded_clauses):
+                embedded_clauses[i] = fill_pred_info(ec)    
+
+                if ec['embedded clauses'] != []: #nested
+                    embedded_clauses[i]['embedded clauses'] = nested_lookup.nested_alter(embedded_clauses[i], 'embedded clauses', nested_fill)
+    
+    #replace original file
+    os.remove(filepath)
+    with open(filepath, 'w') as f:
+        json.dump(data, f, indent=4)
+
+predicate_expander("Annotation\\polar_golden_set.json")
+

--- a/Annotation/polar_golden_set.json
+++ b/Annotation/polar_golden_set.json
@@ -5,9 +5,14 @@
             {
                 "predicate": [
                     {
-                        "str": "aren't sure",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "are",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "sure",
+                        "lemma": "sure",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -23,8 +28,8 @@
                 "predicate": [
                     {
                         "str": "show",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "show",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -40,8 +45,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -57,8 +62,8 @@
                 "predicate": [
                     {
                         "str": "addressing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "address",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -74,8 +79,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -90,9 +95,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is very doubtful",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "doubtful",
+                        "lemma": "doubtful",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -108,8 +118,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -124,9 +134,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is irrelevant",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "irrelevant",
+                        "lemma": "irrelevant",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -141,9 +156,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is random",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "random",
+                        "lemma": "random",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -159,8 +179,8 @@
                 "predicate": [
                     {
                         "str": "decides",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -175,9 +195,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depends on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depends",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -193,8 +218,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -209,9 +234,19 @@
             {
                 "predicate": [
                     {
-                        "str": "are still unclear as to",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "are",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "unclear",
+                        "lemma": "unclear",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "as",
+                        "lemma": "as",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -227,8 +262,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -244,8 +279,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -261,8 +296,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -278,8 +313,8 @@
                 "predicate": [
                     {
                         "str": "indicate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "indicate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -294,9 +329,14 @@
             {
                 "predicate": [
                     {
-                        "str": "'re curious",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "'re",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "curious",
+                        "lemma": "curious",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -309,13 +349,7 @@
         "sentence": "As evidence of this, In Thomas de Quinceys Confessions of an English Opium-Eater (1821, p. 188), it is not Ottoman, nor Chinese addicts about whom he writes, But English opium users: \"I question whether any Turk, of all that ever entered the paradise of opium-eaters, can have had half the pleasure I had.\"",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "question",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether any Turk, of all that ever entered the paradise of opium-eaters, can have had half the pleasure I had.",
                 "embedded clauses": []
@@ -326,13 +360,7 @@
         "sentence": "Most studies using D-aspartic acid supplements did not report whether side effects occurred; long-term studies have not yet been performed using D-aspartic acid.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "report",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether side effects occurred",
                 "embedded clauses": []
@@ -346,8 +374,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -363,8 +391,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -375,26 +403,42 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
                 "clause": "what they can do to make sure they are prepared for the future in terms of their job, money and health",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "make sure",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "they are prepared for the future in terms of their job, money and health",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "understand",
+                            "lemma": "understand",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "constituent",
+                    "clause": "what they can do to make sure they are prepared for the future in terms of their job, money and health",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "make",
+                                    "lemma": "make",
+                                    "POS": "VERB"
+                                },
+                                {
+                                    "str": "sure",
+                                    "lemma": "sure",
+                                    "POS": "ADJ"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "they are prepared for the future in terms of their job, money and health",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -402,13 +446,7 @@
         "sentence": "And these requirements do not reflect the complex and often messy realities of innovation, let alone capture whether the innovation has negative consequences, such as putting CFCs in refrigerators.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "capture",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "the innovation has negative consequences, such as putting CFCs in refrigerators",
                 "embedded clauses": []
@@ -422,8 +460,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -434,8 +472,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -451,8 +489,8 @@
                 "predicate": [
                     {
                         "str": "consider",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "consider",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -468,8 +506,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -484,9 +522,19 @@
             {
                 "predicate": [
                     {
-                        "str": "is not dependent on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "dependent",
+                        "lemma": "dependent",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -501,9 +549,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depends on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depends",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -519,8 +572,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -536,8 +589,8 @@
                 "predicate": [
                     {
                         "str": "considered",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "consider",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -548,8 +601,8 @@
                 "predicate": [
                     {
                         "str": "considered",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "consider",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -565,8 +618,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -582,8 +635,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -599,8 +652,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -616,8 +669,8 @@
                 "predicate": [
                     {
                         "str": "conclude",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "conclude",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -633,8 +686,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -650,8 +703,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -667,8 +720,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -683,9 +736,14 @@
             {
                 "predicate": [
                     {
-                        "str": "known about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "known",
+                        "lemma": "know",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -700,9 +758,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is unknown",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "unknown",
+                        "lemma": "unknown",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -712,9 +775,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is unknown",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "unknown",
+                        "lemma": "unknown",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -730,8 +798,8 @@
                 "predicate": [
                     {
                         "str": "wondered",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -747,8 +815,8 @@
                 "predicate": [
                     {
                         "str": "establish",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "establish",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -764,8 +832,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -781,8 +849,8 @@
                 "predicate": [
                     {
                         "str": "considering",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "consider",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -798,8 +866,8 @@
                 "predicate": [
                     {
                         "str": "consider",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "consider",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -812,13 +880,7 @@
         "sentence": "But nobody continued to question (as they once had) whether or not the internet was really necessary.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "question",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether or not the internet was really necessary",
                 "embedded clauses": []
@@ -829,13 +891,7 @@
         "sentence": "Organic acids testing is a way to measure whether your body is getting and using the nutrients needed for key metabolic processes.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "measure",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether your body is getting and using the nutrients needed for key metabolic processes",
                 "embedded clauses": []
@@ -848,9 +904,14 @@
             {
                 "predicate": [
                     {
-                        "str": "worry about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "worry",
+                        "lemma": "worry",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -865,9 +926,14 @@
             {
                 "predicate": [
                     {
-                        "str": "'s not even clear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "'s",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "clear",
+                        "lemma": "clear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -877,9 +943,14 @@
             {
                 "predicate": [
                     {
-                        "str": "'s not even clear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "'s",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "clear",
+                        "lemma": "clear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "constituent",
@@ -895,8 +966,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -912,8 +983,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -928,9 +999,14 @@
             {
                 "predicate": [
                     {
-                        "str": "to be totally irrelevant",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "be",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "irrelevant",
+                        "lemma": "irrelevant",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -945,9 +1021,14 @@
             {
                 "predicate": [
                     {
-                        "str": "confused as to",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "confused",
+                        "lemma": "confuse",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "as",
+                        "lemma": "as",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -963,8 +1044,8 @@
                 "predicate": [
                     {
                         "str": "doubt",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "doubt",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -980,8 +1061,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -996,9 +1077,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is not relevant",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "relevant",
+                        "lemma": "relevant",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -1014,8 +1100,8 @@
                 "predicate": [
                     {
                         "str": "worrying",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "worry",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1031,8 +1117,8 @@
                 "predicate": [
                     {
                         "str": "say",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "say",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1048,8 +1134,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1065,8 +1151,8 @@
                 "predicate": [
                     {
                         "str": "recognize",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "recognize",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1082,8 +1168,8 @@
                 "predicate": [
                     {
                         "str": "discover",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discover",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1098,9 +1184,14 @@
             {
                 "predicate": [
                     {
-                        "str": "find out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "find",
+                        "lemma": "find",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1116,8 +1207,8 @@
                 "predicate": [
                     {
                         "str": "investigating",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "investigate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1132,9 +1223,14 @@
             {
                 "predicate": [
                     {
-                        "str": "caring about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "caring",
+                        "lemma": "care",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1149,9 +1245,14 @@
             {
                 "predicate": [
                     {
-                        "str": "wondering about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "wondering",
+                        "lemma": "wonder",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1167,8 +1268,8 @@
                 "predicate": [
                     {
                         "str": "knowing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1183,9 +1284,14 @@
             {
                 "predicate": [
                     {
-                        "str": "thinking about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "thinking",
+                        "lemma": "think",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1200,9 +1306,14 @@
             {
                 "predicate": [
                     {
-                        "str": "'s not clear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "'s",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "clear",
+                        "lemma": "clear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -1210,13 +1321,7 @@
                 "embedded clauses": []
             },
             {
-                "predicate": [
-                    {
-                        "str": "'s telling",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "declarative",
                 "clause": "that the investigation is being led by the Niagara Regional Police Service",
                 "embedded clauses": []
@@ -1229,9 +1334,14 @@
             {
                 "predicate": [
                     {
-                        "str": "raging over",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "raging",
+                        "lemma": "rage",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "over",
+                        "lemma": "over",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1241,9 +1351,14 @@
             {
                 "predicate": [
                     {
-                        "str": "raging over",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "raging",
+                        "lemma": "rage",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "over",
+                        "lemma": "over",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1254,8 +1369,8 @@
                 "predicate": [
                     {
                         "str": "think",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "think",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "constituent",
@@ -1271,8 +1386,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1283,8 +1398,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1299,9 +1414,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is doubtful",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "doubtful",
+                        "lemma": "doubtful",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -1317,8 +1437,8 @@
                 "predicate": [
                     {
                         "str": "asking",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1334,8 +1454,8 @@
                 "predicate": [
                     {
                         "str": "analyzing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "analyze",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1351,8 +1471,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1367,9 +1487,14 @@
             {
                 "predicate": [
                     {
-                        "str": "learn more about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "learn",
+                        "lemma": "learn",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1384,9 +1509,14 @@
             {
                 "predicate": [
                     {
-                        "str": "fighting over",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "fighting",
+                        "lemma": "fight",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "over",
+                        "lemma": "over",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1401,9 +1531,14 @@
             {
                 "predicate": [
                     {
-                        "str": "look into",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "look",
+                        "lemma": "look",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "into",
+                        "lemma": "into",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1419,8 +1554,8 @@
                 "predicate": [
                     {
                         "str": "tell",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "tell",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1436,8 +1571,8 @@
                 "predicate": [
                     {
                         "str": "decides",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1453,8 +1588,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1469,9 +1604,14 @@
             {
                 "predicate": [
                     {
-                        "str": "is often unkown",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "is",
+                        "lemma": "be",
+                        "POS": "AUX"
+                    },
+                    {
+                        "str": "unkown",
+                        "lemma": "unkown",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -1487,8 +1627,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1504,8 +1644,8 @@
                 "predicate": [
                     {
                         "str": "understand",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "understand",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1518,13 +1658,7 @@
         "sentence": "Those of us in New Jersey can support the adoption of Senate Bill 677, sponsored by Sen. Ronald L. Rice, which would require our legislature to issue racial impact statements to assess whether proposed legislation will have a disproportionate racial impact.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "assess",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether proposed legislation will have a disproportionate racial impact",
                 "embedded clauses": []
@@ -1537,9 +1671,14 @@
             {
                 "predicate": [
                     {
-                        "str": "remains unclear",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "remains",
+                        "lemma": "remain",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "unclear",
+                        "lemma": "unclear",
+                        "POS": "ADJ"
                     }
                 ],
                 "type": "polar",
@@ -1554,9 +1693,14 @@
             {
                 "predicate": [
                     {
-                        "str": "hinge on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "hinge",
+                        "lemma": "hinge",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1572,8 +1716,8 @@
                 "predicate": [
                     {
                         "str": "discusses",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "discuss",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1589,8 +1733,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1606,8 +1750,8 @@
                 "predicate": [
                     {
                         "str": "realize",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "realize",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1622,9 +1766,14 @@
             {
                 "predicate": [
                     {
-                        "str": "talking about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "talking",
+                        "lemma": "talk",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1640,8 +1789,8 @@
                 "predicate": [
                     {
                         "str": "Measuring",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "measure",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1657,8 +1806,8 @@
                 "predicate": [
                     {
                         "str": "care",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "care",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1669,8 +1818,8 @@
                 "predicate": [
                     {
                         "str": "care",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "care",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -1686,8 +1835,8 @@
                 "predicate": [
                     {
                         "str": "wonder",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1702,9 +1851,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depend on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depend",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1714,9 +1868,14 @@
             {
                 "predicate": [
                     {
-                        "str": "depend on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depend",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1732,8 +1891,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1749,8 +1908,8 @@
                 "predicate": [
                     {
                         "str": "testing",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "test",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1766,8 +1925,8 @@
                 "predicate": [
                     {
                         "str": "monitor",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "monitor",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1783,8 +1942,8 @@
                 "predicate": [
                     {
                         "str": "evaluate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "evaluate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1795,8 +1954,8 @@
                 "predicate": [
                     {
                         "str": "evaluate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "evaluate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1812,8 +1971,8 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1829,8 +1988,8 @@
                 "predicate": [
                     {
                         "str": "known",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1846,8 +2005,8 @@
                 "predicate": [
                     {
                         "str": "known",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1862,27 +2021,48 @@
             {
                 "predicate": [
                     {
-                        "str": "depend on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "depend",
+                        "lemma": "depend",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
                 "clause": "whether the electorate believes he can improve the security situation",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "believes",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "he can improve the security situation",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "depend",
+                            "lemma": "depend",
+                            "POS": "VERB"
+                        },
+                        {
+                            "str": "on",
+                            "lemma": "on",
+                            "POS": "ADP"
+                        }
+                    ],
+                    "type": "polar",
+                    "clause": "whether the electorate believes he can improve the security situation",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "believes",
+                                    "lemma": "believe",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "he can improve the security situation",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -1893,8 +2073,8 @@
                 "predicate": [
                     {
                         "str": "revealed",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "reveal",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1910,26 +2090,31 @@
                 "predicate": [
                     {
                         "str": "found",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "find",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
                 "clause": "that variations in the serotonin transporter gene influence whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin.",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "influence",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "polar",
-                        "clause": "whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin.",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "found",
+                            "lemma": "find",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "declarative",
+                    "clause": "that variations in the serotonin transporter gene influence whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin.",
+                    "embedded clauses": [
+                        {
+                            "predicate": [],
+                            "type": "polar",
+                            "clause": "whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin.",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -1937,13 +2122,7 @@
         "sentence": "We're not sure whether pollsters were referring to Los Stop's version, Con su blanca palidez, though somehow we suspect not.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "sure",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether pollsters were referring to Los Stop's version, Con su blanca palidezs",
                 "embedded clauses": []
@@ -1957,8 +2136,8 @@
                 "predicate": [
                     {
                         "str": "examine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "examine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -1973,9 +2152,14 @@
             {
                 "predicate": [
                     {
-                        "str": "find out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "find",
+                        "lemma": "find",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -1985,9 +2169,14 @@
             {
                 "predicate": [
                     {
-                        "str": "find out",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "find",
+                        "lemma": "find",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "out",
+                        "lemma": "out",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -2003,8 +2192,8 @@
                 "predicate": [
                     {
                         "str": "wonder",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "wonder",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2019,9 +2208,29 @@
             {
                 "predicate": [
                     {
-                        "str": "remained non-committal on",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "remained",
+                        "lemma": "remain",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "non",
+                        "lemma": "non",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "-",
+                        "lemma": "-",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "committal",
+                        "lemma": "committal",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "on",
+                        "lemma": "on",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -2037,8 +2246,8 @@
                 "predicate": [
                     {
                         "str": "asking",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2053,9 +2262,14 @@
             {
                 "predicate": [
                     {
-                        "str": "look into",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "look",
+                        "lemma": "look",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "into",
+                        "lemma": "into",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -2065,9 +2279,14 @@
             {
                 "predicate": [
                     {
-                        "str": "look into",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "look",
+                        "lemma": "look",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "into",
+                        "lemma": "into",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "constituent",
@@ -2082,9 +2301,14 @@
             {
                 "predicate": [
                     {
-                        "str": "inquired further about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "inquired",
+                        "lemma": "inquire",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -2097,13 +2321,7 @@
         "sentence": "For this, the Commission will also assess whether the law provides for a balance between the promotion of Ukrainian and guarantees for minority languages.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "assess",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether the law provides for a balance between the promotion of Ukrainian and guarantees for minority languages",
                 "embedded clauses": []
@@ -2116,27 +2334,48 @@
             {
                 "predicate": [
                     {
-                        "str": "hesitant as to",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "hesitant",
+                        "lemma": "hesitant",
+                        "POS": "ADJ"
+                    },
+                    {
+                        "str": "as",
+                        "lemma": "as",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
                 "clause": "whether we can really say that Jesus and people of his time were ethnically egalitarian in our modern sense",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "say",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that Jesus and people of his time were ethnically egalitarian in our modern sense",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "hesitant",
+                            "lemma": "hesitant",
+                            "POS": "ADJ"
+                        },
+                        {
+                            "str": "as",
+                            "lemma": "as",
+                            "POS": "ADP"
+                        }
+                    ],
+                    "type": "polar",
+                    "clause": "whether we can really say that Jesus and people of his time were ethnically egalitarian in our modern sense",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "say",
+                                    "lemma": "say",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that Jesus and people of his time were ethnically egalitarian in our modern sense",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -2147,8 +2386,8 @@
                 "predicate": [
                     {
                         "str": "evaluate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "evaluate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2164,8 +2403,8 @@
                 "predicate": [
                     {
                         "str": "evaluate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "evaluate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2181,8 +2420,8 @@
                 "predicate": [
                     {
                         "str": "ask",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2198,8 +2437,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2214,9 +2453,14 @@
             {
                 "predicate": [
                     {
-                        "str": "think about",
-                        "lemma": "",
-                        "POS": ""
+                        "str": "think",
+                        "lemma": "think",
+                        "POS": "VERB"
+                    },
+                    {
+                        "str": "about",
+                        "lemma": "about",
+                        "POS": "ADP"
                     }
                 ],
                 "type": "polar",
@@ -2232,8 +2476,8 @@
                 "predicate": [
                     {
                         "str": "deciding",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2244,8 +2488,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2261,8 +2505,8 @@
                 "predicate": [
                     {
                         "str": "dictate",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "dictate",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2273,8 +2517,8 @@
                 "predicate": [
                     {
                         "str": "doubt",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "doubt",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "declarative",
@@ -2287,13 +2531,7 @@
         "sentence": "I am trying to scout whether the Chairperson is here.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "scout",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether the Chairperson is here",
                 "embedded clauses": []
@@ -2304,29 +2542,28 @@
         "sentence": "Temporary Speaker, Sir, I would like the Chairperson to state:- (a) Whether he is aware that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "state",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "Whether he is aware that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "aware",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [],
+                    "type": "polar",
+                    "clause": "Whether he is aware that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "aware",
+                                    "lemma": "aware",
+                                    "POS": "ADJ"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -2337,26 +2574,37 @@
                 "predicate": [
                     {
                         "str": "know",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "know",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
                 "clause": "whether I am the only one who heard my good friend, the simba from Kirinyaga mention that some\"\u009d.\"",
-                "embedded clauses": [
-                    {
-                        "predicate": [
-                            {
-                                "str": "mention",
-                                "lemma": "",
-                                "POS": ""
-                            }
-                        ],
-                        "type": "declarative",
-                        "clause": "that some\"\u009d.\"",
-                        "embedded clauses": []
-                    }
-                ]
+                "embedded clauses": {
+                    "predicate": [
+                        {
+                            "str": "know",
+                            "lemma": "know",
+                            "POS": "VERB"
+                        }
+                    ],
+                    "type": "polar",
+                    "clause": "whether I am the only one who heard my good friend, the simba from Kirinyaga mention that some\"\u009d.\"",
+                    "embedded clauses": [
+                        {
+                            "predicate": [
+                                {
+                                    "str": "mention",
+                                    "lemma": "mention",
+                                    "POS": "VERB"
+                                }
+                            ],
+                            "type": "declarative",
+                            "clause": "that some\"\u009d.\"",
+                            "embedded clauses": []
+                        }
+                    ]
+                }
             }
         ]
     },
@@ -2367,8 +2615,8 @@
                 "predicate": [
                     {
                         "str": "determining",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2384,8 +2632,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2401,8 +2649,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2418,8 +2666,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2430,8 +2678,8 @@
                 "predicate": [
                     {
                         "str": "see",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "see",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2447,8 +2695,8 @@
                 "predicate": [
                     {
                         "str": "consider",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "consider",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2464,8 +2712,8 @@
                 "predicate": [
                     {
                         "str": "asked",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "ask",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2478,13 +2726,7 @@
         "sentence": "I question whether any of this is really possible today, though.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "question",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether any of this is really possible today",
                 "embedded clauses": []
@@ -2498,8 +2740,8 @@
                 "predicate": [
                     {
                         "str": "decide",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2512,13 +2754,7 @@
         "sentence": "For activities within the scope of Annex II of the EIA Regulation (projects subject to election and assessment criteria), an EIA presentation file must be submitted to the Ministry or the relevant authority, who will then assess whether preparation of an EIA report is required for the specific project.",
         "embedded clauses": [
             {
-                "predicate": [
-                    {
-                        "str": "assess",
-                        "lemma": "",
-                        "POS": ""
-                    }
-                ],
+                "predicate": [],
                 "type": "polar",
                 "clause": "whether preparation of an EIA report is required for the specific project",
                 "embedded clauses": []
@@ -2532,8 +2768,8 @@
                 "predicate": [
                     {
                         "str": "deciding",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "decide",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",
@@ -2549,8 +2785,8 @@
                 "predicate": [
                     {
                         "str": "determine",
-                        "lemma": "",
-                        "POS": ""
+                        "lemma": "determine",
+                        "POS": "VERB"
                     }
                 ],
                 "type": "polar",


### PR DESCRIPTION
Includes altered golden sets and the code for altering them. The code for altering them could be modified for use as a tool to navigate the datasets. I included predicate strings (not indices), lemmas, and POS tags.
