### PR TITLE
flatten golden sets

### DIFF
--- a/Annotation/golden_sets_flattened.json
+++ b/Annotation/golden_sets_flattened.json
@@ -1,0 +1,6833 @@
+{
+    "0": {
+        "sentence": "Luminosity Gaming may be about to recruit a new CS:GO player, as VPEsports reports that Ricardo 'boltz' Prass is set to rejoin the side to replace Gustavo 'yeL' Knittel.",
+        "predicate": [
+            {
+                "str": "reports",
+                "lemma": "report",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Ricardo 'boltz' Prass is set to rejoin the side to replace Gustavo 'yeL' Knittel"
+    },
+    "1": {
+        "sentence": "I have always loved fashion and believe that it plays an integral role in self expression",
+        "predicate": [
+            {
+                "str": "believe",
+                "lemma": "believe",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that it plays an integral role in self expression"
+    },
+    "2": {
+        "sentence": "Being a Conroe and Woodlands Family Photographer, I find that emotions are the most noticeable thing in my photographs (especially since I shoot with a candid approach to my sessions)",
+        "predicate": [
+            {
+                "str": "find",
+                "lemma": "find",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that emotions are the most noticeable thing in my photographs (especially since I shoot with a candid approach to my sessions)"
+    },
+    "3": {
+        "sentence": "I can honestly say that that is precisely what happened on this day",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that that is precisely what happened on this day"
+    },
+    "4": {
+        "sentence": "I have decided that I want her to be my pen pal and take it back old school",
+        "predicate": [
+            {
+                "str": "decided",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that I want her to be my pen pal and take it back old school"
+    },
+    "5": {
+        "sentence": "They were up for something different and an adventure, so I felt it was a great opportunity to shoot in!",
+        "predicate": [
+            {
+                "str": "felt",
+                "lemma": "feel",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "it was a great opportunity to shoot in"
+    },
+    "6": {
+        "sentence": "I am also praying that everyone who flooded is doing ok and things are getting back to normal!",
+        "predicate": [
+            {
+                "str": "praying",
+                "lemma": "pray",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that everyone who flooded is doing ok"
+    },
+    "7": {
+        "sentence": "I am also praying that everyone who flooded is doing ok and things are getting back to normal!",
+        "predicate": [
+            {
+                "str": "praying",
+                "lemma": "pray",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "things are getting back to normal"
+    },
+    "8": {
+        "sentence": "I also should mention that Eurri Farris, of Eurri Kim Photography was an amazing help that day, assisting in this session.",
+        "predicate": [
+            {
+                "str": "mention",
+                "lemma": "mention",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Eurri Farris, of Eurri Kim Photography was an amazing help that day, assisting in this session"
+    },
+    "9": {
+        "sentence": "This is not to say that any one of these reasons were the cause or causes of any of the head-on collisions in Missouri in the last three months",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that any one of these reasons were the cause or causes of any of the head-on collisions in Missouri in the last three months"
+    },
+    "10": {
+        "sentence": "When we laid our foundation stone in Denver, CO 80211 almost 10 years ago, we realized that the people of the city have been desperately missing the services of a professional locksmith company",
+        "predicate": [
+            {
+                "str": "realized",
+                "lemma": "realize",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that the people of the city have been desperately missing the services of a professional locksmith company"
+    },
+    "11": {
+        "sentence": "For anyone following Tiny Tim\u2019s adventures, we know that he lives with his mum and has never met his real dad",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that he lives with his mum"
+    },
+    "12": {
+        "sentence": "For anyone following Tiny Tim\u2019s adventures, we know that he lives with his mum and has never met his real dad",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "has never met his real dad"
+    },
+    "13": {
+        "sentence": "@avoto hm, I don't think that it's a good idea",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that it's a good idea"
+    },
+    "14": {
+        "sentence": "@PaulMaly_twitter I was thinking that there can be more than one version where one is is the Ractive component file as per the official spec",
+        "predicate": [
+            {
+                "str": "thinking",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that there can be more than one version where one is is the Ractive component file as per the official spec"
+    },
+    "15": {
+        "sentence": "I think the components should be written so that they could work without any compilation at least in one environment",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "the components should be written so that they could work without any compilation at least in one environment"
+    },
+    "16": {
+        "sentence": "All right, I was really bad at photographing this weekend, but just trust me when I say that it was filled with good things: fireplaces, hot apple cider, laughs, the picture game, a skype date with my brother, exploring, and, and, and",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that it was filled with good things: fireplaces, hot apple cider, laughs, the picture game, a skype date with my brother, exploring, and, and, and"
+    },
+    "17": {
+        "sentence": "Here I argue that despite the good intentions of euthanasia advocates, their understanding of mercy is flawed",
+        "predicate": [
+            {
+                "str": "argue",
+                "lemma": "argue",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that despite the good intentions of euthanasia advocates, their understanding of mercy is flawed"
+    },
+    "18": {
+        "sentence": "Euthanasia advocates believe that intentionally taking the life of someone who is terminally ill or suffering severe pain constitutes an act of mercy",
+        "predicate": [
+            {
+                "str": "believe",
+                "lemma": "believe",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that intentionally taking the life of someone who is terminally ill or suffering severe pain constitutes an act of mercy"
+    },
+    "19": {
+        "sentence": "Yet, if we deny that Jones\u2019 life has any real meaning because his pain outweighs his enjoyment of life then his worth is reduced to the sum total of the pain or the pleasure he is experiencing",
+        "predicate": [
+            {
+                "str": "deny",
+                "lemma": "deny",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Jones\u2019 life has any real meaning because his pain outweighs his enjoyment of life"
+    },
+    "20": {
+        "sentence": "Ethics academic Gilbert Meilaender holds that such thinking forces us to speak of ourselves in terms of \u201cwhat we have\u201d instead of \u201cwho we are\u201d (http://www.firstthings.com/article.php3?id_article=6047)",
+        "predicate": [
+            {
+                "str": "holds",
+                "lemma": "hold",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that such thinking forces us to speak of ourselves in terms of \u201cwhat we have\u201d instead of \u201cwho we are\u201d"
+    },
+    "21": {
+        "sentence": "My parents have worked all of their lives and they always told me whether it is just a part-time job, a volunteer job, or your career, if you agreed to work for someone, do just that.",
+        "predicate": [
+            {
+                "str": "told",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "whether it is just a part-time job, a volunteer job, or your career, if you agreed to work for someone, do just that"
+    },
+    "22": {
+        "sentence": "It is to admit that doctors are in some way divorced from their patients and unaffected by the treatment they provide to them.",
+        "predicate": [
+            {
+                "str": "admit",
+                "lemma": "admit",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that doctors are in some way divorced from their patients and unaffected by the treatment they provide to them"
+    },
+    "23": {
+        "sentence": "However, defining mercy solely as relationship might indicate that euthanasia is not incompatible with mercy",
+        "predicate": [
+            {
+                "str": "indicate",
+                "lemma": "indicate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that euthanasia is not incompatible with mercy"
+    },
+    "24": {
+        "sentence": "However, to accept this definition of relationship is to admit that a doctor who provides Jones with a lethal injection acts in a way that is morally equivalent to a doctor who nurses Jones to his death",
+        "predicate": [
+            {
+                "str": "admit",
+                "lemma": "admit",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that a doctor who provides Jones with a lethal injection acts in a way that is morally equivalent to a doctor who nurses Jones to his death"
+    },
+    "25": {
+        "sentence": "In A Common Humanity: Thinking about Love and Truth and Justice (2000) Gaita writes: \u201cOften, we learn that something is precious only when we see it in the light of someone\u2019s love\u201d",
+        "predicate": [
+            {
+                "str": "write",
+                "lemma": "write",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "\u201cOften, we learn that something is precious only when we see it in the light of someone\u2019s love\u201d"
+    },
+    "26": {
+        "sentence": "In A Common Humanity: Thinking about Love and Truth and Justice (2000) Gaita writes: \u201cOften, we learn that something is precious only when we see it in the light of someone\u2019s love\u201d",
+        "predicate": [
+            {
+                "str": "learn",
+                "lemma": "learn",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that something is precious"
+    },
+    "27": {
+        "sentence": "Therefore, by loving Jones or by seeing that Jones is loved, we realise Jones to be a person with inherent dignity",
+        "predicate": [
+            {
+                "str": "seeing",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Jones is loved"
+    },
+    "28": {
+        "sentence": "A new report is saying that new car sales took a nosedive in September, signaling economic distress could be just around the corner",
+        "predicate": [
+            {
+                "str": "saying",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that new car sales took a nosedive in September"
+    },
+    "29": {
+        "sentence": "A new report is saying that new car sales took a nosedive in September, signaling economic distress could be just around the corner",
+        "predicate": [
+            {
+                "str": "signaling",
+                "lemma": "signal",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "economic distress could be just around the corner"
+    },
+    "30": {
+        "sentence": "News BREAKING: HHA owner Jon Kelly has revealed he was sacked on Monday as administrators Ferrier Hodgson announced the business was in voluntary administration.",
+        "predicate": [
+            {
+                "str": "revealed",
+                "lemma": "reveal",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "he was sacked on Monday"
+    },
+    "31": {
+        "sentence": "News BREAKING: HHA owner Jon Kelly has revealed he was sacked on Monday as administrators Ferrier Hodgson announced the business was in voluntary administration.",
+        "predicate": [
+            {
+                "str": "announced",
+                "lemma": "announce",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "the business was in voluntary administration"
+    },
+    "32": {
+        "sentence": "\u201cProfessor Carter's research is so important in preserving the planet, and I'd like to think that I'm contributing in my own small way,\u201d said Baughman, who worked at Firestone Library from 2006 to 2008 and returned to Princeton in 2013.",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "\u201cProfessor Carter's research is so important in preserving the planet, and I'd like to think that I'm contributing in my own small way,\u201d"
+    },
+    "33": {
+        "sentence": "\u201cProfessor Carter's research is so important in preserving the planet, and I'd like to think that I'm contributing in my own small way,\u201d said Baughman, who worked at Firestone Library from 2006 to 2008 and returned to Princeton in 2013.",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that I'm contributing in my own small way"
+    },
+    "34": {
+        "sentence": "Did I forget to mention the home has 3 zone heat and Air conditioning on 1.8 acres of property on a no thruway street",
+        "predicate": [
+            {
+                "str": "mention",
+                "lemma": "mention",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "the home has 3 zone heat and Air conditioning on 1.8 acres of property on a no thruway street"
+    },
+    "35": {
+        "sentence": "Ready-made Greens can be useful for mixing other colours too, we\u2019re not suggesting you should chuck them out!",
+        "predicate": [
+            {
+                "str": "suggesting",
+                "lemma": "suggest",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "you should chuck them out"
+    },
+    "36": {
+        "sentence": "You will see that small differences in the amount of black can make a big difference to the colour you make.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that small differences in the amount of black can make a big difference to the colour you make"
+    },
+    "37": {
+        "sentence": "One study found that variations in the serotonin transporter gene influence whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin.",
+        "predicate": [
+            {
+                "str": "found",
+                "lemma": "find",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that variations in the serotonin transporter gene influence whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin."
+    },
+    "38": {
+        "sentence": "One study found that variations in the serotonin transporter gene influence whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin.",
+        "predicate": [
+            {
+                "str": "influence",
+                "lemma": "influence",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not a person will respond to an antidepressant such as an SSRI, which acts upon serotonin."
+    },
+    "39": {
+        "sentence": "I have so many things I want to write about I fear I\u2019m bursting at the seams",
+        "predicate": [
+            {
+                "str": "fear",
+                "lemma": "fear",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "I\u2019m bursting at the seams"
+    },
+    "40": {
+        "sentence": "I think I was so stunned that it was meant for him that I didn\u2019t get it at first, until my friend hit me hard in the leg and she said to me \u201cDid YOU HEAR THAT??\u201d And I look at C\u2019s dad and he\u2019s saying the same",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "I was so stunned that it was meant for him"
+    },
+    "41": {
+        "sentence": "I think I was so stunned that it was meant for him that I didn\u2019t get it at first, until my friend hit me hard in the leg and she said to me \u201cDid YOU HEAR THAT??\u201d And I look at C\u2019s dad and he\u2019s saying the same",
+        "predicate": [
+            {
+                "str": "was",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "stunned",
+                "lemma": "stunned",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that it was meant for him"
+    },
+    "42": {
+        "sentence": "I think I was so stunned that it was meant for him that I didn\u2019t get it at first, until my friend hit me hard in the leg and she said to me \u201cDid YOU HEAR THAT??\u201d And I look at C\u2019s dad and he\u2019s saying the same",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "\u201cDid YOU HEAR THAT??\u201d"
+    },
+    "43": {
+        "sentence": "In these classes there is such a mixture he understands that he can do so much more then he thought he could.",
+        "predicate": [
+            {
+                "str": "understands",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that he can do so much more then he thought he could"
+    },
+    "44": {
+        "sentence": "In these classes there is such a mixture he understands that he can do so much more then he thought he could.",
+        "predicate": [
+            {
+                "str": "thought",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "he could"
+    },
+    "45": {
+        "sentence": "He\u2019s also told me he wants to try out for football next year",
+        "predicate": [
+            {
+                "str": "told",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "he wants to try out for football next year"
+    },
+    "46": {
+        "sentence": "I don\u2019t think I\u2019m ready for the pain that\u2019s going to go along with the teenage years",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "I\u2019m ready for the pain that\u2019s going to go along with the teenage years"
+    },
+    "47": {
+        "sentence": "To any studio execs who may be reading this: I can't guarantee that following my advice will help your format win the war, but doing so will certainly improve your products, and should make High-Def discs more appealing to your target customers.",
+        "predicate": [
+            {
+                "str": "guarantee",
+                "lemma": "guarantee",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that following my advice will help your format win the war"
+    },
+    "48": {
+        "sentence": "I realize this may sound like a contradiction to my last point about getting straight to the movie, but the fact of the matter is that High-Def discs usually have a number of audio, subtitle, and other setup choices to dig through before you can finally sit down to watch the movie",
+        "predicate": [
+            {
+                "str": "realize",
+                "lemma": "realize",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "this may sound like a contradiction to my last point about getting straight to the movie"
+    },
+    "49": {
+        "sentence": "Just to reiterate that while I appreciate, and even enjoy, contact from readers, I'm absolutely not interested in whatever spammy commercial venture you're proposing",
+        "predicate": [
+            {
+                "str": "reiterate",
+                "lemma": "reiterate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that while I appreciate, and even enjoy, contact from readers, I'm absolutely not interested in whatever spammy commercial venture you're proposing"
+    },
+    "50": {
+        "sentence": "And that Jamie Schler article\u2026I wish I were as fiery",
+        "predicate": [
+            {
+                "str": "wish",
+                "lemma": "wish",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "I were as fiery"
+    },
+    "51": {
+        "sentence": "I think not letting one\u2019s computer get in the way of real life is sound advice",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "not letting one\u2019s computer get in the way of real life is sound advice"
+    },
+    "52": {
+        "sentence": "Later in the article, Portnoy says that for all the freedom the site allots its various personalities, the one topic Barstool bloggers and readers are both actively uninterested in is politics, a topic that\u2019s infiltrated the sports world to an unprecedented degree in recent years due to the National Anthem protests, among other things.",
+        "predicate": [
+            {
+                "str": "says",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that for all the freedom the site allots its various personalities, the one topic Barstool bloggers and readers are both actively uninterested in is politics, a topic that\u2019s infiltrated the sports world to an unprecedented degree in recent years due to the National Anthem protests, among other things"
+    },
+    "53": {
+        "sentence": "No matter how ridiculous the jokes, or over the top the take, it was understood by most that we are just here to make people laugh.",
+        "predicate": [
+            {
+                "str": "understood",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that we are just here to make people laugh"
+    },
+    "54": {
+        "sentence": "On that count, he knows all too well that a combative, anti-PC, anti-moral grandstanding ethos is morphing into a political ideology unto itself\u2014one that Barstool is both defining and capitalizing on.",
+        "predicate": [
+            {
+                "str": "knows",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that a combative, anti-PC, anti-moral grandstanding ethos is morphing into a political ideology unto itself\u2014one that Barstool is both defining and capitalizing on"
+    },
+    "55": {
+        "sentence": "and I guess they smelt well.",
+        "predicate": [
+            {
+                "str": "guess",
+                "lemma": "guess",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "they smelt well"
+    },
+    "56": {
+        "sentence": "Michelle Obama says her family has decided to make a Portuguese Water Dog the first dog around the Obama White House",
+        "predicate": [
+            {
+                "str": "says",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "her family has decided to make a Portuguese Water Dog the first dog around the Obama White House"
+    },
+    "57": {
+        "sentence": "The First Lady told People Magazine the Obamas are searching animal rescues for that particular breed.",
+        "predicate": [
+            {
+                "str": "told",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "the Obamas are searching animal rescues for that particular breed"
+    },
+    "58": {
+        "sentence": "Obama says she hopes the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break.",
+        "predicate": [
+            {
+                "str": "says",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "she hopes the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break"
+    },
+    "59": {
+        "sentence": "Obama says she hopes the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break.",
+        "predicate": [
+            {
+                "str": "hopes",
+                "lemma": "hope",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "the lucky Portuguese Water Dog will move into the White House in April after she and President Obama take their daughters on Spring Break"
+    },
+    "60": {
+        "sentence": "Obama says she learned from Sen",
+        "predicate": [
+            {
+                "str": "says",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "she learned from Sen"
+    },
+    "61": {
+        "sentence": "I know that Apple does provide a converter that turns the charging port into a headphone jack, but this means you have to do a lot of plugging and unplugging every time you want to listen to music - and since my strength is limited, that's difficult for me",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Apple does provide a converter that turns the charging port into a headphone jack"
+    },
+    "62": {
+        "sentence": "I know that Apple does provide a converter that turns the charging port into a headphone jack, but this means you have to do a lot of plugging and unplugging every time you want to listen to music - and since my strength is limited, that's difficult for me",
+        "predicate": [
+            {
+                "str": "means",
+                "lemma": "mean",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "you have to do a lot of plugging and unplugging every time you want to listen to music"
+    },
+    "63": {
+        "sentence": "Is it accurate to say that you are a specialist in a particular field?",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that you are a specialist in a particular field"
+    },
+    "64": {
+        "sentence": "From movement, form, cooking, to DIY, and expulsion administrations, on the off chance that you realize how to accomplish something especially well, why not tell the world through a blog or video blog?",
+        "predicate": [
+            {
+                "str": "realize",
+                "lemma": "realize",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how to accomplish something especially well"
+    },
+    "65": {
+        "sentence": "I know you have made a planned to leave your 9-to-5 job",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "you have made a planned to leave your 9-to-5 job"
+    },
+    "66": {
+        "sentence": "Plus, I don\u2019t think I barely snacked at all",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "I barely snacked at all"
+    },
+    "67": {
+        "sentence": "I too have been upping the healthy fats in my diet an have definitely noticed that I can last for up to 6 hours without feeling hunger pains!!",
+        "predicate": [
+            {
+                "str": "noticed",
+                "lemma": "notice",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that I can last for up to 6 hours without feeling hunger pains"
+    },
+    "68": {
+        "sentence": "Some people say that you shouldn\u2019t eat a lot of fats when you eat a raw diet, as it is hard on the digestive tract",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that you shouldn\u2019t eat a lot of fats when you eat a raw diet, as it is hard on the digestive tract"
+    },
+    "69": {
+        "sentence": "Do you think the 01753476428 was a harass phone number?",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "the 01753476428 was a harass phone number"
+    },
+    "70": {
+        "sentence": "NationalLedger.com reports that Christina Aguilera risked re-igniting her feud with Britney Spears by a comment made on her wedding day",
+        "predicate": [
+            {
+                "str": "reports",
+                "lemma": "report",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Christina Aguilera risked re-igniting her feud with Britney Spears by a comment made on her wedding day"
+    },
+    "71": {
+        "sentence": "Christina\u2019s rep denies she made any comment however.",
+        "predicate": [
+            {
+                "str": "denies",
+                "lemma": "deny",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "she made any comment"
+    },
+    "72": {
+        "sentence": "In this sense, Mignolo argues that while modernity is not strictly a European phenomenon, its rhetoric -as Dussel argues- is formed by European philosophers, academics and politicians",
+        "predicate": [
+            {
+                "str": "argues",
+                "lemma": "argue",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that while modernity is not strictly a European phenomenon, its rhetoric -as Dussel argues- is formed by European philosophers, academics and politicians"
+    },
+    "73": {
+        "sentence": "Business guests appreciate that our downtown hotel's location in Lexington, KY is close to IBM, PNC Bank, Fifth Third Bank, Ashland and UPS",
+        "predicate": [
+            {
+                "str": "appreciate",
+                "lemma": "appreciate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that our downtown hotel's location in Lexington, KY is close to IBM, PNC Bank, Fifth Third Bank, Ashland and UPS"
+    },
+    "74": {
+        "sentence": "AEPi is proud to say that we are one of the loudest Jewish voices on campus",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that we are one of the loudest Jewish voices on campus"
+    },
+    "75": {
+        "sentence": "On January 31, 2015, The Sacramento Bee reported that the AEPi building in Davis had been tagged with two large swastikas",
+        "predicate": [
+            {
+                "str": "reported",
+                "lemma": "report",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that the AEPi building in Davis had been tagged with two large swastikas"
+    },
+    "76": {
+        "sentence": "I think this is just too cool for school!!!!!",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "this is just too cool for school"
+    },
+    "77": {
+        "sentence": "With this issue, they said they thought it was a virus and would have it running the next day",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "they thought it was a virus"
+    },
+    "78": {
+        "sentence": "With this issue, they said they thought it was a virus and would have it running the next day",
+        "predicate": [
+            {
+                "str": "thought",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "it was a virus"
+    },
+    "79": {
+        "sentence": "With this issue, they said they thought it was a virus and would have it running the next day",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "would have it running the next day"
+    },
+    "80": {
+        "sentence": "Click said that would not be an issue.",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that would not be an issue"
+    },
+    "81": {
+        "sentence": "I checked in with the in 2 days (when the repair should have been complete) and was told it would be one more day - they were doing some final tests",
+        "predicate": [
+            {
+                "str": "told",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "it would be one more day - they were doing some final tests"
+    },
+    "82": {
+        "sentence": "The next day I learned that they had not put any real time evaluating my laptop and would require a couple more days",
+        "predicate": [
+            {
+                "str": "learned",
+                "lemma": "learn",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that they had not put any real time evaluating my laptop and would require a couple more days"
+    },
+    "83": {
+        "sentence": "After two more days they said they needed to repair the backlight before trying to determine the other problem",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "they needed to repair the backlight before trying to determine the other problem"
+    },
+    "84": {
+        "sentence": "\u200bDigging a little deeper, we managed to find out that Carole Baskin, CEO of Big Cat Rescue, and Wayne Pacelle, CEO of the HSUS, are former colleagues.",
+        "predicate": [
+            {
+                "str": "find",
+                "lemma": "find",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Carole Baskin, CEO of Big Cat Rescue, and Wayne Pacelle, CEO of the HSUS, are former colleagues"
+    },
+    "85": {
+        "sentence": "It's interesting to know that Wayne was a co-founder of the Humane Society Legislative Fund",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Wayne was a co-founder of the Humane Society Legislative Fund"
+    },
+    "86": {
+        "sentence": "At Radon Fan Guys, we understand that you have to stay within your price range and save cash everywhere you're able to",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that you have to stay within your price range and save cash everywhere you're able to"
+    },
+    "87": {
+        "sentence": "We use the finest materials and techniques to ensure that your task is going to tolerate the years, and cost less money with techniques which do not affect the excellence of any project",
+        "predicate": [
+            {
+                "str": "ensure",
+                "lemma": "ensure",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that your task is going to tolerate the years, and cost less money with techniques which do not affect the excellence of any project"
+    },
+    "88": {
+        "sentence": "Then he shocked her by declaring that he was offering \u201cliving water\u201d greater than Jacob\u2019s well, greater than either the Temple or the holy places of Samaria",
+        "predicate": [
+            {
+                "str": "declaring",
+                "lemma": "declare",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that he was offering \u201cliving water\u201d greater than Jacob\u2019s well, greater than either the Temple or the holy places of Samaria"
+    },
+    "89": {
+        "sentence": "The Founders Scholarship was created in 2010 by fifteen individuals or couples to ensure that all graduating Mackinac Island students have an opportunity for a multi-year scholarship award",
+        "predicate": [
+            {
+                "str": "ensure",
+                "lemma": "ensure",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that all graduating Mackinac Island students have an opportunity for a multi-year scholarship award"
+    },
+    "90": {
+        "sentence": "The Local Government Association estimates that by 2025, the funding gap will grow to \u00a33bn for children\u2019s social care alone.",
+        "predicate": [
+            {
+                "str": "estimates",
+                "lemma": "estimate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that by 2025, the funding gap will grow to \u00a33bn for children\u2019s social care alone"
+    },
+    "91": {
+        "sentence": "We are told that ministers are minded to appoint a commissioner shortly to intervene in the council\u2019s operations to stabilise and improve child protection services",
+        "predicate": [
+            {
+                "str": "told",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that ministers are minded to appoint a commissioner shortly to intervene in the council\u2019s operations to stabilise and improve child protection services"
+    },
+    "92": {
+        "sentence": "Northampton\u2019s leader, Matt Golby, has been quoted as saying that no children will be put in danger as a result of propose cuts, but it is difficult to see how this could be the case",
+        "predicate": [
+            {
+                "str": "saying",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that no children will be put in danger as a result of propose cuts"
+    },
+    "93": {
+        "sentence": "Northampton\u2019s leader, Matt Golby, has been quoted as saying that no children will be put in danger as a result of propose cuts, but it is difficult to see how this could be the case",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how this could be the case"
+    },
+    "94": {
+        "sentence": "But the government is already backing down on this claim, with Jo Farrar, director general to the Ministry of Housing, Communities and Local Government, telling the public accounts committee this week that they do not expect these funds to buy additional capacity",
+        "predicate": [
+            {
+                "str": "telling",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that they do not expect these funds to buy additional capacity"
+    },
+    "95": {
+        "sentence": "She believes this map will help students complete their homework on time.",
+        "predicate": [
+            {
+                "str": "believes",
+                "lemma": "believe",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "this map will help students complete their homework on time"
+    },
+    "96": {
+        "sentence": "In this criminal complaint, the government claims that Khaalid Adam Abdulkadir made death threats against FBI agents in various Twitter posts",
+        "predicate": [
+            {
+                "str": "claims",
+                "lemma": "claim",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Khaalid Adam Abdulkadir made death threats against FBI agents in various Twitter posts"
+    },
+    "97": {
+        "sentence": "The government agreed that its informant was responsible for first alerting law enforcement to the Twitter communications, but refused disclosure under the government\u2013informant privilege.",
+        "predicate": [
+            {
+                "str": "agreed",
+                "lemma": "agree",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that its informant was responsible for first alerting law enforcement to the Twitter communications"
+    },
+    "98": {
+        "sentence": "The court held that Abdulkadir failed to show that the FBI\u2019s confidential informant was material to his defense",
+        "predicate": [
+            {
+                "str": "held",
+                "lemma": "hold",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Abdulkadir failed to show that the FBI\u2019s confidential informant was material to his defense"
+    },
+    "99": {
+        "sentence": "The court held that Abdulkadir failed to show that the FBI\u2019s confidential informant was material to his defense",
+        "predicate": [
+            {
+                "str": "show",
+                "lemma": "show",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that the FBI\u2019s confidential informant was material to his defense"
+    },
+    "100": {
+        "sentence": "The court noted that the case remains in the pre-indictment stage, and will permit Abdulkadir to renew his motion at a later date",
+        "predicate": [
+            {
+                "str": "noted",
+                "lemma": "note",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that the case remains in the pre-indictment stage"
+    },
+    "101": {
+        "sentence": "The sting operation, however, allegedly reveals that our personal data may not be totally secure in the hands of a digital payments giant and that it may have sold it to other third-parties out there",
+        "predicate": [
+            {
+                "str": "reveals",
+                "lemma": "reveal",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that our personal data may not be totally secure in the hands of a digital payments giant"
+    },
+    "102": {
+        "sentence": "The sting operation, however, allegedly reveals that our personal data may not be totally secure in the hands of a digital payments giant and that it may have sold it to other third-parties out there",
+        "predicate": [
+            {
+                "str": "reveals",
+                "lemma": "reveal",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that it may have sold it to other third-parties out there"
+    },
+    "103": {
+        "sentence": "Please ensure you revisit this page and re\u2013check for any updates/changes before the date of the fixture.",
+        "predicate": [
+            {
+                "str": "ensure",
+                "lemma": "ensure",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "you revisit this page and re\u2013check for any updates/changes before the date of the fixture"
+    },
+    "104": {
+        "sentence": "I know these are just models, but we always like to share them with you",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "these are just models"
+    },
+    "105": {
+        "sentence": "Many have been speculating that the announcement is for the long awaited next installment in the Persona series",
+        "predicate": [
+            {
+                "str": "speculating",
+                "lemma": "speculate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that the announcement is for the long awaited next installment in the Persona series"
+    },
+    "106": {
+        "sentence": "You could argue that these elements fall under the category of story, which Persona 3 won anyway, but I feel they are significant enough to make a difference",
+        "predicate": [
+            {
+                "str": "argue",
+                "lemma": "argue",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that these elements fall under the category of story, which Persona 3 won anyway"
+    },
+    "107": {
+        "sentence": "You could argue that these elements fall under the category of story, which Persona 3 won anyway, but I feel they are significant enough to make a difference",
+        "predicate": [
+            {
+                "str": "feel",
+                "lemma": "feel",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "they are significant enough to make a difference"
+    },
+    "108": {
+        "sentence": "This is to inform you that you have been selected for a cash prize of \u00a3850,000.00 (Eight hundred and fifty thousand Great British Pounds) from the BMW AUTOMOBILE GROUP e-LOTTERY BONANZA International programs held TODAY Teusday the 6th of MARCH 2007, here in London United Kingdom.",
+        "predicate": [
+            {
+                "str": "inform",
+                "lemma": "inform",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that you have been selected for a cash prize of \u00a3850,000.00 (Eight hundred and fifty thousand Great British Pounds) from the BMW AUTOMOBILE GROUP e-LOTTERY BONANZA International programs held TODAY Teusday the 6th of MARCH 2007, here in London United Kingdom"
+    },
+    "109": {
+        "sentence": "I think that does a good job of summarising my feelings towards friends who drift away over time.",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that does a good job of summarising my feelings towards friends who drift away over time"
+    },
+    "110": {
+        "sentence": "According to the Children's Action Network, nationwide each year 20,000 children age out of the foster care system, but experts say they are still in need of a family as they embark on work and college.",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "they are still in need of a family as they embark on work and college"
+    },
+    "111": {
+        "sentence": "Executive producer Brandon Margolis revealed that Fletcher, the hacker who helps Mike and Marcus in both films, would also appear in the show.",
+        "predicate": [
+            {
+                "str": "revealed",
+                "lemma": "reveal",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Fletcher, the hacker who helps Mike and Marcus in both films, would also appear in the show"
+    },
+    "112": {
+        "sentence": "Valentino still loves MotoGP and last year he demonstrated that he still can be competitive",
+        "predicate": [
+            {
+                "str": "demonstrated",
+                "lemma": "demonstrate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "he still can be competitive"
+    },
+    "113": {
+        "sentence": "Maverick Vinales admits he was puzzled by why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one.",
+        "predicate": [
+            {
+                "str": "admits",
+                "lemma": "admit",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "he was puzzled by why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one"
+    },
+    "114": {
+        "sentence": "Maverick Vinales admits he was puzzled by why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one.",
+        "predicate": [
+            {
+                "str": "puzzled",
+                "lemma": "puzzle",
+                "POS": "VERB"
+            },
+            {
+                "str": "by",
+                "lemma": "by",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why he was uncompetitive on the second day of Valencia's post-season MotoGP test on Wednesday having topped the times on day one"
+    },
+    "115": {
+        "sentence": "Repsol Honda Team Principal Livio Suppo has said that he and Honda aren\u2019t surprised by the pace and performances of new Yamaha recruit Maverick Vi\u00f1ales, but that they are of his team-mate, Valentino Rossi.",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that he and Honda aren\u2019t surprised by the pace and performances of new Yamaha recruit Maverick Vi\u00f1ales, but that they are of his team-mate, Valentino Rossi"
+    },
+    "116": {
+        "sentence": "Introducing the bill, Law Minister Ravi Shankar Prasad said despite the Supreme Court striking down the practice of talaq-e-biddat (instant triple talaq) as unconstitutional, men were divorcing their wives on flimsy grounds and even via Whatsapp.",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "despite the Supreme Court striking down the practice of talaq-e-biddat (instant triple talaq) as unconstitutional, men were divorcing their wives on flimsy grounds and even via Whatsapp"
+    },
+    "117": {
+        "sentence": "Putin, speaking in International Investments Forum in Sochi, said that Russia's inflation rate would be 7 percent this year.",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Russia's inflation rate would be 7 percent this year"
+    },
+    "118": {
+        "sentence": "He reminded that in 2009, Russia's GDP dropped by 7.9 percent, inflation reached 9 percent.",
+        "predicate": [
+            {
+                "str": "reminded",
+                "lemma": "remind",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that in 2009, Russia's GDP dropped by 7.9 percent, inflation reached 9 percent"
+    },
+    "119": {
+        "sentence": "August was the first month since May when industrial output in Russia was above zero and reaches 0.1 percent, thus Nabiullina called August \"a good month\", admitting that in agricultural sector growth was negative by 9.6 percent.",
+        "predicate": [
+            {
+                "str": "admitting",
+                "lemma": "admit",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that in agricultural sector growth was negative by 9.6 percent"
+    },
+    "120": {
+        "sentence": "i have ensured that the wireless sync is activated on the handhelds as well",
+        "predicate": [
+            {
+                "str": "ensured",
+                "lemma": "ensure",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that the wireless sync is activated on the handhelds as well"
+    },
+    "121": {
+        "sentence": "Firstly, I must say that my comments below are not a criticism of teachers, who work very hard against all the odds, but of education systems that have 'lost their way'",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that my comments below are not a criticism of teachers, who work very hard against all the odds, but of education systems that have 'lost their way'"
+    },
+    "122": {
+        "sentence": "I believe only the chemistry specialist has the 'depth of knowledge' to enthuse the students, which in turn leads to an increased uptake in the subject.",
+        "predicate": [
+            {
+                "str": "believe",
+                "lemma": "believe",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "only the chemistry specialist has the 'depth of knowledge' to enthuse the students, which in turn leads to an increased uptake in the subject"
+    },
+    "123": {
+        "sentence": "74% thought it was too noisy.",
+        "predicate": [
+            {
+                "str": "thought",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "it was too noisy"
+    },
+    "124": {
+        "sentence": "81% said the bathroom was dirty.",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "the bathroom was dirty"
+    },
+    "125": {
+        "sentence": "Everyone is aware that finding someone close to you can be tiring, so we founded our site with three ideas as our goal: we want to make finding locals easy, mobile, and totally free",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "aware",
+                "lemma": "aware",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that finding someone close to you can be tiring"
+    },
+    "126": {
+        "sentence": "Simply adjust your settings and know you will find exactly who you want at the ideal time for you.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "you will find exactly who you want at the ideal time for you"
+    },
+    "127": {
+        "sentence": "I\u2019ve been blogging for over three years now, mostly as a passion and I have only became more professional in the recent months but never thought I\u2019d end up making up a start a blog tutorial",
+        "predicate": [
+            {
+                "str": "thought",
+                "lemma": "think",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "I\u2019d end up making up a start a blog tutorial"
+    },
+    "128": {
+        "sentence": "That makes me really happy, I know I had a hard time getting a blog up!",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "I had a hard time getting a blog up"
+    },
+    "129": {
+        "sentence": "Please note you will be billed a year a time, but as you can see, it works out to a very reasonable monthly amount",
+        "predicate": [
+            {
+                "str": "note",
+                "lemma": "note",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "you will be billed a year a time"
+    },
+    "130": {
+        "sentence": "Fill in your billing information, confirm that you\u2019ve read the fine print and then click Next.",
+        "predicate": [
+            {
+                "str": "confirm",
+                "lemma": "confirm",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that you\u2019ve read the fine print"
+    },
+    "131": {
+        "sentence": "I hope my start a blog tutorial has been of help and I look forward to hear your input and also read your new, beautiful blogs",
+        "predicate": [
+            {
+                "str": "hope",
+                "lemma": "hope",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "my start a blog tutorial has been of help"
+    },
+    "132": {
+        "sentence": "Irving Azoff Claims YouTube \"Pirates\" Are \"Really Evil\"",
+        "predicate": [
+            {
+                "str": "Claims",
+                "lemma": "claim",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "YouTube \"Pirates\" Are \"Really Evil\""
+    },
+    "133": {
+        "sentence": "Will Someone Explain To The RIAA That SOPA Didn't Pass?",
+        "predicate": [
+            {
+                "str": "explain",
+                "lemma": "explain",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "That SOPA Didn't Pass"
+    },
+    "134": {
+        "sentence": "(Buffalo, NY) \u2013 New York State Senator Chris Jacobs announced that he has secured $120,000 in state funding for the twelve branch libraries in the 60th Senate District",
+        "predicate": [
+            {
+                "str": "announced",
+                "lemma": "announce",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that he has secured $120,000 in state funding for the twelve branch libraries in the 60th Senate District"
+    },
+    "135": {
+        "sentence": "Having a graduating senior has finally forced my hand to figure out how to bring our video archives into this new Internets thingy.",
+        "predicate": [
+            {
+                "str": "figure",
+                "lemma": "figure",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how to bring our video archives into this new Internets thingy"
+    },
+    "136": {
+        "sentence": "I get why there is a Michigan culture that supports hunting and related lifestyle.",
+        "predicate": [
+            {
+                "str": "get",
+                "lemma": "get",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why there is a Michigan culture that supports hunting and related lifestyle"
+    },
+    "137": {
+        "sentence": "Unfortunately, I also understand why there are a very small percentage of zealots who take the guns and rugged independence and separate society to an extreme, and that\u2019s why we end up with groups like the Michigan Militia from the 1990s and now the Hutaree of today.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why there are a very small percentage of zealots who take the guns and rugged independence and separate society to an extreme"
+    },
+    "138": {
+        "sentence": "To get the most beneficial bumper boat, one which is well-made and may last for quite some time, you have to know how to decide on the correct manufacturer.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how to decide on the correct manufacturer"
+    },
+    "139": {
+        "sentence": "You simply need to know how to locate them and evaluate each company.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how to locate them and evaluate each company"
+    },
+    "140": {
+        "sentence": "Query why, exactly, we allow a tax deduction for charitable giving.",
+        "predicate": [
+            {
+                "str": "Query",
+                "lemma": "query",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why, exactly, we allow a tax deduction for charitable giving"
+    },
+    "141": {
+        "sentence": "In this article, we try to understand how people made sense of a family death, within the social contexts of their lives.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how people made sense of a family death, within the social contexts of their lives"
+    },
+    "142": {
+        "sentence": "We discuss how people made sense of the family death in relation to three main contexts: family, religion, and materiality.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how people made sense of the family death in relation to three main contexts: family, religion, and materiality"
+    },
+    "143": {
+        "sentence": "One should never apologize for how they are feeling.",
+        "predicate": [
+            {
+                "str": "apologize",
+                "lemma": "apologize",
+                "POS": "VERB"
+            },
+            {
+                "str": "for",
+                "lemma": "for",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how they are feeling"
+    },
+    "144": {
+        "sentence": "Whether the judge will agree with Rocco depends on what Rocco's reasons are for wanting to live with his father in London.",
+        "predicate": [
+            {
+                "str": "depends",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what Rocco's reasons are for wanting to live with his father in London"
+    },
+    "145": {
+        "sentence": "Find out how you can take your business to the next level in Washington State by contacting one of our business experts right now!",
+        "predicate": [
+            {
+                "str": "Find",
+                "lemma": "find",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how you can take your business to the next level in Washington State"
+    },
+    "146": {
+        "sentence": "Clearer, perhaps, than even Action Comics #775, the conclusion of In the Name of Gog demonstrates why Superman is the world's greatest super-hero, bar none.",
+        "predicate": [
+            {
+                "str": "demonstrates",
+                "lemma": "demonstrate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why Superman is the world's greatest super-hero, bar none"
+    },
+    "147": {
+        "sentence": "And the Nightwing/Superboy pairing is ingenious; it makes you wonder why no one's put these two legacy heroes together before, and I'm eager to see how that plays out in Teen Titans: Life and Death.",
+        "predicate": [
+            {
+                "str": "wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why no one's put these two legacy heroes together before"
+    },
+    "148": {
+        "sentence": "And the Nightwing/Superboy pairing is ingenious; it makes you wonder why no one's put these two legacy heroes together before, and I'm eager to see how that plays out in Teen Titans: Life and Death.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how that plays out in Teen Titans: Life and Death"
+    },
+    "149": {
+        "sentence": "It remains to be seen how DC might collect the various crossover miniseries specials, however, perhaps along with the lead story from the Infinite Crisis Secret Files.",
+        "predicate": [
+            {
+                "str": "seen",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how DC might collect the various crossover miniseries specials, however, perhaps along with the lead story from the Infinite Crisis Secret Files"
+    },
+    "150": {
+        "sentence": "Whether Vengeance will include Sam Loeb's #26, and how DC will collect Mark Verheiden's issues after Jeph Loeb departs, remains to be seen.",
+        "predicate": [
+            {
+                "str": "seen",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "Whether Vengeance will include Sam Loeb's #26"
+    },
+    "151": {
+        "sentence": "Whether Vengeance will include Sam Loeb's #26, and how DC will collect Mark Verheiden's issues after Jeph Loeb departs, remains to be seen.",
+        "predicate": [
+            {
+                "str": "seen",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how DC will collect Mark Verheiden's issues after Jeph Loeb departs"
+    },
+    "152": {
+        "sentence": "I was sad and upset at a lot of her decisions but I understood how messed up things were for her.",
+        "predicate": [
+            {
+                "str": "understood",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how messed up things were for her"
+    },
+    "153": {
+        "sentence": "This explains why imported basic commodities, such as chicken, milk and toilet paper, are now scarce, just as in the old Soviet Union, or in today\u2019s Cuba.",
+        "predicate": [
+            {
+                "str": "explains",
+                "lemma": "explain",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why imported basic commodities, such as chicken, milk and toilet paper, are now scarce, just as in the old Soviet Union, or in today\u2019s Cuba"
+    },
+    "154": {
+        "sentence": "Delving into history, I hear the refrain, \u201cBREAD and CIRCUSES\u201d The Roman emperors kept the Roman mob satisfied with bread and circuses, food and entertainment, (now you understand why the liberal elite controls Hollywood,) while looting the empire to pay for the bread and the circuses, and to quiet the mob.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why the liberal elite controls Hollywood"
+    },
+    "155": {
+        "sentence": "However, it\u2019s important to discuss the way In the Future came to be and how the process impacts the album.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how the process impacts the album"
+    },
+    "156": {
+        "sentence": "In an article explaining why the Conservancy is stepping up its collaboration with IHA, which you can read in full here, its Director of Sustainable Hydropower Dr. Jeff Opperman said, We want to do our part to help create a future world, one where people can live, learn and thrive supported by a sustainable energy system and one that harbours beautiful and productive rivers, including wild ones.",
+        "predicate": [
+            {
+                "str": "explaining",
+                "lemma": "explain",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why the Conservancy is stepping up its collaboration with IHA"
+    },
+    "157": {
+        "sentence": "In an article explaining why the Conservancy is stepping up its collaboration with IHA, which you can read in full here, its Director of Sustainable Hydropower Dr. Jeff Opperman said, We want to do our part to help create a future world, one where people can live, learn and thrive supported by a sustainable energy system and one that harbours beautiful and productive rivers, including wild ones.",
+        "predicate": [
+            {
+                "str": "said",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "We want to do our part to help create a future world, one where people can live, learn and thrive supported by a sustainable energy system and one that harbours beautiful and productive rivers, including wild ones"
+    },
+    "158": {
+        "sentence": "We are happy to discuss your case and how we can help you.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how we can help you"
+    },
+    "159": {
+        "sentence": "Everybody's motivations are reasonable, but it's not too clear why Troy doesn't just sit tight behind its imposing walls.",
+        "predicate": [
+            {
+                "str": "'s",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "clear",
+                "lemma": "clear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why Troy doesn't just sit tight behind its imposing walls"
+    },
+    "160": {
+        "sentence": "But one of the questions I asked myself is, I wonder how many people talk with God even a fraction of the time they spend on their cell phone?",
+        "predicate": [
+            {
+                "str": "wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how many people talk with God even a fraction of the time they spend on their cell phone"
+    },
+    "161": {
+        "sentence": "We work with the client to discuss how they plan on incorporating the strategic plan, who will be involved, how detailed of a plan they need for their organization, how they plan on communicating it, and, if they have a board, how they will be involved in the process.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how they plan on incorporating the strategic plan"
+    },
+    "162": {
+        "sentence": "We work with the client to discuss how they plan on incorporating the strategic plan, who will be involved, how detailed of a plan they need for their organization, how they plan on communicating it, and, if they have a board, how they will be involved in the process.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "who will be involved"
+    },
+    "163": {
+        "sentence": "We work with the client to discuss how they plan on incorporating the strategic plan, who will be involved, how detailed of a plan they need for their organization, how they plan on communicating it, and, if they have a board, how they will be involved in the process.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how detailed of a plan they need for their organization"
+    },
+    "164": {
+        "sentence": "We work with the client to discuss how they plan on incorporating the strategic plan, who will be involved, how detailed of a plan they need for their organization, how they plan on communicating it, and, if they have a board, how they will be involved in the process.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how they plan on communicating it"
+    },
+    "165": {
+        "sentence": "We work with the client to discuss how they plan on incorporating the strategic plan, who will be involved, how detailed of a plan they need for their organization, how they plan on communicating it, and, if they have a board, how they will be involved in the process.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how they will be involved in the process"
+    },
+    "166": {
+        "sentence": "-- When Lamar Jackson is asked about how much he has grown, the Baltimore Ravens quarterback thinks to last year's practices where he would get the play from a coach and try to repeat it in the huddle before stopping.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how much he has grown"
+    },
+    "167": {
+        "sentence": "I cannot wait to see how this thing ends up.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how this thing ends up"
+    },
+    "168": {
+        "sentence": "First, however, it would be very useful for the Wall Street Journal to explain, in clear and simple language, how handing over near-total control of the financial markets and the creation of money and credit to the State is in any way promoting \"the cause of free markets.\"",
+        "predicate": [
+            {
+                "str": "explain",
+                "lemma": "explain",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how handing over near-total control of the financial markets and the creation of money and credit to the State is in any way promoting \"the cause of free markets.\""
+    },
+    "169": {
+        "sentence": "I don't know how long awhile will be.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how long awhile will be"
+    },
+    "170": {
+        "sentence": "I usually went along and listened because I am interested enough to spend a couple of hours hearing why people think Amway is a good idea.",
+        "predicate": [
+            {
+                "str": "hearing",
+                "lemma": "hear",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why people think Amway is a good idea"
+    },
+    "171": {
+        "sentence": "\u201cSpare time is a foreign concept to us\u201d, Ben answered when I asked how swamped they get before a tour.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how swamped they get before a tour"
+    },
+    "172": {
+        "sentence": "A journalist once asked us how we were doing so well.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how we were doing so well"
+    },
+    "173": {
+        "sentence": "Well, since my husband's father suffered from dementia and I know how confused they can get, I could already relate to his issues.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how confused they can get"
+    },
+    "174": {
+        "sentence": "Even less frequently do we hear of how the survivors continue with their lives and search for some sort of resolution.",
+        "predicate": [
+            {
+                "str": "hear",
+                "lemma": "hear",
+                "POS": "VERB"
+            },
+            {
+                "str": "of",
+                "lemma": "of",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how the survivors continue with their lives and search for some sort of resolution"
+    },
+    "175": {
+        "sentence": "Despite the heavy topic, \"While We Slept\" is indeed a book of hope and redemption worth reading for anyone who has ever stopped and wondered why anyone would kill and what could be done about it.",
+        "predicate": [
+            {
+                "str": "wondered",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why anyone would kill"
+    },
+    "176": {
+        "sentence": "Despite the heavy topic, \"While We Slept\" is indeed a book of hope and redemption worth reading for anyone who has ever stopped and wondered why anyone would kill and what could be done about it.",
+        "predicate": [
+            {
+                "str": "wondered",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what could be done about it"
+    },
+    "177": {
+        "sentence": "Great story and once you read it, you will totally see how real and honest they are about how they could forgive.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how real and honest they are about how they could forgive"
+    },
+    "178": {
+        "sentence": "Great story and once you read it, you will totally see how real and honest they are about how they could forgive.",
+        "predicate": [
+            {
+                "str": "real",
+                "lemma": "real",
+                "POS": "ADJ"
+            },
+            {
+                "str": "honest",
+                "lemma": "honest",
+                "POS": "ADJ"
+            },
+            {
+                "str": "are",
+                "lemma": "be",
+                "POS": "AUX"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how they could forgive"
+    },
+    "179": {
+        "sentence": "Greenwood clearly demonstrates how this demand can be met in cases where textual evidence is plentiful, be it in the form of published monographs and commentaries or private letters and notebooks.",
+        "predicate": [
+            {
+                "str": "demonstrates",
+                "lemma": "demonstrate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how this demand can be met in cases where textual evidence is plentiful, be it in the form of published monographs and commentaries or private letters and notebooks"
+    },
+    "180": {
+        "sentence": "It is situations like this that truly test our patience, and the subsequent decisions we make reflect who we are, what we stand for, and what kind of role model we will be for our children.",
+        "predicate": [
+            {
+                "str": "reflect",
+                "lemma": "reflect",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "who we are"
+    },
+    "181": {
+        "sentence": "It is situations like this that truly test our patience, and the subsequent decisions we make reflect who we are, what we stand for, and what kind of role model we will be for our children.",
+        "predicate": [
+            {
+                "str": "reflect",
+                "lemma": "reflect",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what we stand for"
+    },
+    "182": {
+        "sentence": "It is situations like this that truly test our patience, and the subsequent decisions we make reflect who we are, what we stand for, and what kind of role model we will be for our children.",
+        "predicate": [
+            {
+                "str": "reflect",
+                "lemma": "reflect",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what kind of role model we will be for our children"
+    },
+    "183": {
+        "sentence": "It is not known when the hostages - whose nationality was not immediately known - were seized.",
+        "predicate": [
+            {
+                "str": "known",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "when the hostages - whose nationality was not immediately known - were seized"
+    },
+    "184": {
+        "sentence": "Keith Carr, who has now retired, remembers when he went to treat him in 2013.",
+        "predicate": [
+            {
+                "str": "remembers",
+                "lemma": "remember",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "when he went to treat him in 2013"
+    },
+    "185": {
+        "sentence": "The aim is to show spectators how litter is harming our waterways and killing marine life both here and out at sea.",
+        "predicate": [
+            {
+                "str": "show",
+                "lemma": "show",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how litter is harming our waterways and killing marine life both here and out at sea"
+    },
+    "186": {
+        "sentence": "He says how he much he has enjoyed working for the council and nothing ever made him want to leave.",
+        "predicate": [
+            {
+                "str": "says",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how he much he has enjoyed working for the council and nothing ever made him want to leave"
+    },
+    "187": {
+        "sentence": "He says how he much he has enjoyed working for the council and nothing ever made him want to leave.",
+        "predicate": [
+            {
+                "str": "says",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "nothing ever made him want to leave"
+    },
+    "188": {
+        "sentence": "While thanking voters, Jon explained how the future of the party is going to look.",
+        "predicate": [
+            {
+                "str": "explained",
+                "lemma": "explain",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how the future of the party is going to look"
+    },
+    "189": {
+        "sentence": "He also plans to develop his own career but failed to comment on how or what he is planning.",
+        "predicate": [
+            {
+                "str": "comment",
+                "lemma": "comment",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how"
+    },
+    "190": {
+        "sentence": "He also plans to develop his own career but failed to comment on how or what he is planning.",
+        "predicate": [
+            {
+                "str": "comment",
+                "lemma": "comment",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what he is planning"
+    },
+    "191": {
+        "sentence": "Twickenham Film Studios has tweeted how their thoughts are with those affected by the fire that broke out in Liverpool\u2019s Littlewood building last night.",
+        "predicate": [
+            {
+                "str": "tweeted",
+                "lemma": "tweet",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how their thoughts are with those affected by the fire that broke out in Liverpool\u2019s Littlewood building last night"
+    },
+    "192": {
+        "sentence": "It is not known as yet which production team members will be presented to Charles and Camilla.",
+        "predicate": [
+            {
+                "str": "known",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "which production team members will be presented to Charles and Camilla"
+    },
+    "193": {
+        "sentence": "And did she ask who the next Doctor might be?",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "who the next Doctor might be"
+    },
+    "194": {
+        "sentence": "Everybody else in the building has asked me who the next Doctor is, and I can tell you honestly we don't know.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "who the next Doctor is"
+    },
+    "195": {
+        "sentence": "Everybody else in the building has asked me who the next Doctor is, and I can tell you honestly we don't know.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "we don't know"
+    },
+    "196": {
+        "sentence": "Richard E Grant is back with his evil Great Intelligence, the Doctor\u2019s greatest secret is revealed, all of his friends rally round to protect him and we finally understand why the Doctor has met Clara so many different times.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why the Doctor has met Clara so many different times"
+    },
+    "197": {
+        "sentence": "And on romance: Perhaps, you'll have to wait and see - god knows how he'd react to romance, the Doctor - or my Doctor, anyway!\"",
+        "predicate": [
+            {
+                "str": "knows",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how he'd react to romance"
+    },
+    "198": {
+        "sentence": "The Doctor returns to contemporary London and finds himself meeting Clara Oswald for the third time; he\u2019s been searching the universe for her, but will she even know who he is?",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "who he is"
+    },
+    "199": {
+        "sentence": "As the newest edition to the show, Jenna explains how this series will take the viewer on the same journey of discovery she experienced when she first joined, especially for episode two - The Rings of Akhaten - which is set on an alien planet.",
+        "predicate": [
+            {
+                "str": "explains",
+                "lemma": "explain",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how this series will take the viewer on the same journey of discovery she experienced when she first joined"
+    },
+    "200": {
+        "sentence": "It remains unclear who will be the host of the annual event.",
+        "predicate": [
+            {
+                "str": "remains",
+                "lemma": "remain",
+                "POS": "VERB"
+            },
+            {
+                "str": "unclear",
+                "lemma": "unclear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "constituent",
+        "clause": "who will be the host of the annual event"
+    },
+    "201": {
+        "sentence": "Let me take a moment to tell you what is this all about and how it got started.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what is this all about"
+    },
+    "202": {
+        "sentence": "Let me take a moment to tell you what is this all about and how it got started.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how it got started"
+    },
+    "203": {
+        "sentence": "To see how his slightly left-of-center orientation (or left-of-right, as the case may be) means that he is a slightly controversial figure in some circles today see here, including an oft-repeated rumor about why his notes are in that Talmud edition (and therefore almost all editions since) Also here.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how his slightly left-of-center orientation (or left-of-right, as the case may be) means that he is a slightly controversial figure in some circles today"
+    },
+    "204": {
+        "sentence": "To see how his slightly left-of-center orientation (or left-of-right, as the case may be) means that he is a slightly controversial figure in some circles today see here, including an oft-repeated rumor about why his notes are in that Talmud edition (and therefore almost all editions since) Also here.",
+        "predicate": [
+            {
+                "str": "means",
+                "lemma": "mean",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that he is a slightly controversial figure in some circles today"
+    },
+    "205": {
+        "sentence": "In this issue of Perspectives, we asked an alumna, staff member, faculty member, and current student to discuss how communication has changed with technology.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how communication has changed with technology"
+    },
+    "206": {
+        "sentence": "Peter Pond Society Newsletter 1 relates how the site was originally pinpointed with the help of airplane surveillance in 1942.",
+        "predicate": [
+            {
+                "str": "relates",
+                "lemma": "relate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how the site was originally pinpointed with the help of airplane surveillance in 1942"
+    },
+    "207": {
+        "sentence": "I often reflect on how incredibly lucky I am to have such close links with my extended family and that is in no small part down to you.",
+        "predicate": [
+            {
+                "str": "reflect",
+                "lemma": "reflect",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how incredibly lucky I am to have such close links with my extended family"
+    },
+    "208": {
+        "sentence": "It is wonderful too how many new memories you have been able to be a part of in recent years.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "wonderful",
+                "lemma": "wonderful",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how many new memories you have been able to be a part of in recent years"
+    },
+    "209": {
+        "sentence": "The best way to start is to take one of the short orientation tours just to get a feel for the town and also to know what bus to catch to go where you wish.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what bus to catch to go where you wish"
+    },
+    "210": {
+        "sentence": "Can you imagine what can be taught about sex for 12 or 15 years?",
+        "predicate": [
+            {
+                "str": "imagine",
+                "lemma": "imagine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what can be taught about sex for 12 or 15 years"
+    },
+    "211": {
+        "sentence": "A wife can rightly tell the pastor, You do not know what I have to go through.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "You do not know what I have to go through"
+    },
+    "212": {
+        "sentence": "A wife can rightly tell the pastor, You do not know what I have to go through.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what I have to go through"
+    },
+    "213": {
+        "sentence": "You want to know what you can build on your property, so you consult the zoning code again.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what you can build on your property"
+    },
+    "214": {
+        "sentence": "The field is open for other scholars to build on and explore not only issues of policy and representation in Mexico, but also investigate what if anything has proven effective in combating gender violence, as well as researching how the different levels measured by the Gender Inequality Index affect change.",
+        "predicate": [
+            {
+                "str": "investigate",
+                "lemma": "investigate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what if anything has proven effective in combating gender violence"
+    },
+    "215": {
+        "sentence": "The field is open for other scholars to build on and explore not only issues of policy and representation in Mexico, but also investigate what if anything has proven effective in combating gender violence, as well as researching how the different levels measured by the Gender Inequality Index affect change.",
+        "predicate": [
+            {
+                "str": "researching",
+                "lemma": "research",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how the different levels measured by the Gender Inequality Index affect change"
+    },
+    "216": {
+        "sentence": "I put the case back on the phone, wondering what to do next.",
+        "predicate": [
+            {
+                "str": "wondering",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what to do next"
+    },
+    "217": {
+        "sentence": "I asked numerous times what was going on but they weren\u2019t really sure.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what was going on"
+    },
+    "218": {
+        "sentence": "As a result, we decided last year to take things a step further and ask the publishers what their top 5 most anticipated novels of the year were.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what their top 5 most anticipated novels of the year were"
+    },
+    "219": {
+        "sentence": "Who decides what should be a World Heritage site?",
+        "predicate": [
+            {
+                "str": "decides",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what should be a World Heritage site"
+    },
+    "220": {
+        "sentence": "Just take the time to read these notes and this earlier blog entry, so that you know what to expect, and plunge yourself in the vibrant, ever expanding universe of Detective Conan \u201cwhere high adventure and mystery awaits all who seek it!\u201d",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what to expect"
+    },
+    "221": {
+        "sentence": "Bobby, you really know what it takes to get the girl!",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what it takes to get the girl"
+    },
+    "222": {
+        "sentence": "Each isomer can be synthesized using the trans effect to control which isomer is produced.",
+        "predicate": [
+            {
+                "str": "control",
+                "lemma": "control",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "which isomer is produced"
+    },
+    "223": {
+        "sentence": "No money coming in, money going out, into August now still no job, got the family together & explained the situation to them, down to enough for 3 house payments left, don\u2019t know what lies ahead for us.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what lies ahead for us"
+    },
+    "224": {
+        "sentence": "Trying to think of what I could do with my new toy, my thoughts naturally turned to the projects I've been working on recently -- compilers and a dynamic language runtime.",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            },
+            {
+                "str": "of",
+                "lemma": "of",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what I could do with my new toy"
+    },
+    "225": {
+        "sentence": "Sometimes in real life, you wont know what value to use here, and it\u2019s beyond the scope of this article to talk about how to choose values.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what value to use here"
+    },
+    "226": {
+        "sentence": "Sometimes in real life, you wont know what value to use here, and it\u2019s beyond the scope of this article to talk about how to choose values.",
+        "predicate": [
+            {
+                "str": "talk",
+                "lemma": "talk",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how to choose values"
+    },
+    "227": {
+        "sentence": "He didn\u2019t know what caused Ida to say the next thing.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what caused Ida to say the next thing"
+    },
+    "228": {
+        "sentence": "He remembered the instant his father realized what was happening.",
+        "predicate": [
+            {
+                "str": "realized",
+                "lemma": "realize",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what was happening"
+    },
+    "229": {
+        "sentence": "If you ever want to know what it feels like to be the best-dressed person in the room then get yourself a handcrafted leather iPhone case.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what it feels like to be the best-dressed person in the room"
+    },
+    "230": {
+        "sentence": "His first foray was in the field of plant reproductive biology, in which he learned why two medicinal plants are going extinct in nature.",
+        "predicate": [
+            {
+                "str": "learned",
+                "lemma": "learn",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why two medicinal plants are going extinct in nature"
+    },
+    "231": {
+        "sentence": "The researchers used big data sets collected from seismic waves formed during earthquakes to probe what's happening deep in Earth's interior.",
+        "predicate": [
+            {
+                "str": "probe",
+                "lemma": "probe",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what's happening deep in Earth's interior"
+    },
+    "232": {
+        "sentence": "How mantle flows on Earth might control why there is life on our planet but not on other planets, such as Venus, which has a similar size and location in the solar system to Earth, but likely has a very different style of mantle flow.",
+        "predicate": [
+            {
+                "str": "control",
+                "lemma": "control",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why there is life on our planet but not on other planets, such as Venus, which has a similar size and location in the solar system to Earth, but likely has a very different style of mantle flow"
+    },
+    "233": {
+        "sentence": "The children could not tell me where they came from or what they had been through, but I could see their trauma in the way a tiny girl panicked when a child snatched her toy, and from the big tears that filled a little boy\u2019s eyes as his mother left him to meet with a volunteer.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "where they came from"
+    },
+    "234": {
+        "sentence": "The children could not tell me where they came from or what they had been through, but I could see their trauma in the way a tiny girl panicked when a child snatched her toy, and from the big tears that filled a little boy\u2019s eyes as his mother left him to meet with a volunteer.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what they had been through"
+    },
+    "235": {
+        "sentence": "We can\u2019t know what their futures will hold.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what their futures will hold"
+    },
+    "236": {
+        "sentence": "It has been a very long time since my last update, I can't even remember when it was... or what it was about!",
+        "predicate": [
+            {
+                "str": "remember",
+                "lemma": "remember",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "when it was"
+    },
+    "237": {
+        "sentence": "It has been a very long time since my last update, I can't even remember when it was... or what it was about!",
+        "predicate": [
+            {
+                "str": "remember",
+                "lemma": "remember",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what it was about"
+    },
+    "238": {
+        "sentence": "You never know when you meet new blogger friends, what is safe\" to talk about and what is not.\"",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what is safe\" to talk about"
+    },
+    "239": {
+        "sentence": "You never know when you meet new blogger friends, what is safe\" to talk about and what is not.\"",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what is not"
+    },
+    "240": {
+        "sentence": "In the mean time, here's an image (unfinished) that I created trying to flesh out what Othello would look like as a younger mouse.",
+        "predicate": [
+            {
+                "str": "flesh",
+                "lemma": "flesh",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what Othello would look like as a younger mouse"
+    },
+    "241": {
+        "sentence": "It focuses mainly on Megan and how she\u2019s thinking and feeling, and what she\u2019s going to do, and less so on what happens to her physically, but it was good!",
+        "predicate": [
+            {
+                "str": "focuses",
+                "lemma": "focus",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how she\u2019s thinking and feeling"
+    },
+    "242": {
+        "sentence": "It focuses mainly on Megan and how she\u2019s thinking and feeling, and what she\u2019s going to do, and less so on what happens to her physically, but it was good!",
+        "predicate": [
+            {
+                "str": "focuses",
+                "lemma": "focus",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what she\u2019s going to do"
+    },
+    "243": {
+        "sentence": "It focuses mainly on Megan and how she\u2019s thinking and feeling, and what she\u2019s going to do, and less so on what happens to her physically, but it was good!",
+        "predicate": [
+            {
+                "str": "focuses",
+                "lemma": "focus",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what happens to her physically"
+    },
+    "244": {
+        "sentence": "She kept pestering Megan about what she was going to do, and had she told her Mum, she just wasn\u2019t helping at all.",
+        "predicate": [
+            {
+                "str": "pestering",
+                "lemma": "pester",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what she was going to do"
+    },
+    "245": {
+        "sentence": "Through those conversations, everything was explained bout what Megan\u2019s options were; keeping the baby or having it adopted, and what either choice would mean for her as she is 15.",
+        "predicate": [
+            {
+                "str": "explained",
+                "lemma": "explain",
+                "POS": "VERB"
+            },
+            {
+                "str": "bout",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what Megan\u2019s options were; keeping the baby or having it adopted"
+    },
+    "246": {
+        "sentence": "Through those conversations, everything was explained bout what Megan\u2019s options were; keeping the baby or having it adopted, and what either choice would mean for her as she is 15.",
+        "predicate": [
+            {
+                "str": "explained",
+                "lemma": "explain",
+                "POS": "VERB"
+            },
+            {
+                "str": "bout",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what either choice would mean for her as she is 15"
+    },
+    "247": {
+        "sentence": "We need to think about what is needed to help us do both these things at the same time.",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what is needed to help us do both these things at the same time"
+    },
+    "248": {
+        "sentence": "I'm not sure what Zhawq does, but I'm very aware of when I'm doing it nowadays.",
+        "predicate": [
+            {
+                "str": "'m",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "sure",
+                "lemma": "sure",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what Zhawq does"
+    },
+    "249": {
+        "sentence": "I'm not sure what Zhawq does, but I'm very aware of when I'm doing it nowadays.",
+        "predicate": [
+            {
+                "str": "'m",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "aware",
+                "lemma": "aware",
+                "POS": "ADJ"
+            },
+            {
+                "str": "of",
+                "lemma": "of",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "when I'm doing it"
+    },
+    "250": {
+        "sentence": "Not until the early 20th century did we even realize what those fuzzy patches of light were.",
+        "predicate": [
+            {
+                "str": "realize",
+                "lemma": "realize",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what those fuzzy patches of light were"
+    },
+    "251": {
+        "sentence": "We now know what this looks like at a cellular level.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what this looks like at a cellular level"
+    },
+    "252": {
+        "sentence": "And, I want to know what happened.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what happened"
+    },
+    "253": {
+        "sentence": "Jessica: And so it is this idea of just accepting who you are as a person and what you\u2019re like as a person.",
+        "predicate": [
+            {
+                "str": "accepting",
+                "lemma": "accept",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "who you are as a person"
+    },
+    "254": {
+        "sentence": "Jessica: And so it is this idea of just accepting who you are as a person and what you\u2019re like as a person.",
+        "predicate": [
+            {
+                "str": "accepting",
+                "lemma": "accept",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what you\u2019re like as a person"
+    },
+    "255": {
+        "sentence": "In this way they remotely measure the wind at height, for example, to distinguish which of two differing model predictions most accurately represents reality.",
+        "predicate": [
+            {
+                "str": "distinguish",
+                "lemma": "distinguish",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "which of two differing model predictions most accurately represents reality"
+    },
+    "256": {
+        "sentence": "It's impossible to find out what that half-life is, which means that it is very hard to use it to estimate how much time it will stay in your system.",
+        "predicate": [
+            {
+                "str": "find",
+                "lemma": "find",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what that half-life is"
+    },
+    "257": {
+        "sentence": "It's impossible to find out what that half-life is, which means that it is very hard to use it to estimate how much time it will stay in your system.",
+        "predicate": [
+            {
+                "str": "estimate",
+                "lemma": "estimate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how much time it will stay in your system"
+    },
+    "258": {
+        "sentence": "They read the question cards on the table and mused about what they\u2019d take to a desert island and what chore they\u2019d choose never to do again.",
+        "predicate": [
+            {
+                "str": "mused",
+                "lemma": "muse",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what they\u2019d take to a desert island"
+    },
+    "259": {
+        "sentence": "They read the question cards on the table and mused about what they\u2019d take to a desert island and what chore they\u2019d choose never to do again.",
+        "predicate": [
+            {
+                "str": "mused",
+                "lemma": "muse",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what chore they\u2019d choose never to do again"
+    },
+    "260": {
+        "sentence": "You have a right to ask what information Agape Wellbeing holds about you and for a copy of that information to be made available to you.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what information Agape Wellbeing holds about you"
+    },
+    "261": {
+        "sentence": "But of course, you know what we really need?",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what we really need"
+    },
+    "262": {
+        "sentence": "Consumer-side technology is also seeing growth, as medical-marijuana users try to figure out what works for their ailments and recreational users search for the strains that make them feel a certain way.",
+        "predicate": [
+            {
+                "str": "figure",
+                "lemma": "figure",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what works for their ailments"
+    },
+    "263": {
+        "sentence": "Say things a number of different ways and decide which one you want to lead with.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "which one you want to lead with"
+    },
+    "264": {
+        "sentence": "He better know what he's doing, Pat told herself as she tried to slow the spin, growing more uncomfortable with her situation by the moment.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what he's doing"
+    },
+    "265": {
+        "sentence": "Sometimes our customers don\u2019t really know what needs they have and what problems they\u2019re having until we actually go in and roll up our sleeves and talk to them.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what needs they have"
+    },
+    "266": {
+        "sentence": "Sometimes our customers don\u2019t really know what needs they have and what problems they\u2019re having until we actually go in and roll up our sleeves and talk to them.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what problems they\u2019re having"
+    },
+    "267": {
+        "sentence": "His main responsibility is to raise the creativity for companies that hire him so that they decide themselves what measures need to be taken.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what measures need to be taken"
+    },
+    "268": {
+        "sentence": "Man, you don't even know WHAT I'm thinking right now.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "WHAT I'm thinking right now"
+    },
+    "269": {
+        "sentence": "And I don't know what you're thinking right now...nor do I want to know.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what you're thinking right now"
+    },
+    "270": {
+        "sentence": "Once I know which angles are of most interest to you, I would be happy to provide sidebar ideas, an estimated word count and a working title.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "which angles are of most interest to you"
+    },
+    "271": {
+        "sentence": "Sometimes, I wonder what made me change that much.",
+        "predicate": [
+            {
+                "str": "wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what made me change that much"
+    },
+    "272": {
+        "sentence": "It's the fact you know what's going to happen in each chapter, to each character and what's going on throughout the book.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what's going to happen in each chapter, to each character"
+    },
+    "273": {
+        "sentence": "It's the fact you know what's going to happen in each chapter, to each character and what's going on throughout the book.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what's going on throughout the book"
+    },
+    "274": {
+        "sentence": "I might see what other ARC books are on offer next year to take part in.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what other ARC books are on offer next year to take part in"
+    },
+    "275": {
+        "sentence": "Now, for those of you who don't know what Myers is, it's a major department store here in Australia which is usually very expensive.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what Myers is"
+    },
+    "276": {
+        "sentence": "I don't know what happened, or why this has happened, but it's been going really well.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what happened"
+    },
+    "277": {
+        "sentence": "I don't know what happened, or why this has happened, but it's been going really well.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "why this has happened"
+    },
+    "278": {
+        "sentence": "Let us all know what you're reading and your opinions of your favourite authors at this time of year.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what you're reading"
+    },
+    "279": {
+        "sentence": "It makes me think about how to write what I want to put out there instead of just typing it out.",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how to write what I want to put out there instead of just typing it out"
+    },
+    "280": {
+        "sentence": "This time, I want to ask you, my readers, what your most favourite books of all time are and how many times you've read them.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what your most favourite books of all time are"
+    },
+    "281": {
+        "sentence": "This time, I want to ask you, my readers, what your most favourite books of all time are and how many times you've read them.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how many times you've read them"
+    },
+    "282": {
+        "sentence": "Ever wondered what it is like to hear from your loved one that they have been diagnosed with cancer?",
+        "predicate": [
+            {
+                "str": "wondered",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what it is like to hear from your loved one that they have been diagnosed with cancer"
+    },
+    "283": {
+        "sentence": "Ever wondered what it is like to hear from your loved one that they have been diagnosed with cancer?",
+        "predicate": [
+            {
+                "str": "hear",
+                "lemma": "hear",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that they have been diagnosed with cancer"
+    },
+    "284": {
+        "sentence": "I don't know what it was but I was so distressed and so upset that I just ate it.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what it was"
+    },
+    "285": {
+        "sentence": "The first step to setting an intention is deciding what you would like to put your energy towards in your life.",
+        "predicate": [
+            {
+                "str": "deciding",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what you would like to put your energy towards in your life"
+    },
+    "286": {
+        "sentence": "I would like to know what exit strategy the Chinese central bank has, if any...",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what exit strategy the Chinese central bank has, if any"
+    },
+    "287": {
+        "sentence": "I know exactly what I want in my head, I just have to make it work for the house.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what I want in my head"
+    },
+    "288": {
+        "sentence": "Even his friends aren't sure whether he should come back, leading to a frank discussion of resurrection in the Marvel Universe.",
+        "predicate": [
+            {
+                "str": "are",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "sure",
+                "lemma": "sure",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether he should come back"
+    },
+    "289": {
+        "sentence": "Thus water placed in a vessel with a shaving of camphor thrown upon it will show whether the vessel is clean or not.",
+        "predicate": [
+            {
+                "str": "show",
+                "lemma": "show",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the vessel is clean or not"
+    },
+    "290": {
+        "sentence": "This inquiry will help the reader understand whether a relationship between Mexican female politicians and policies created against violence exists.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a relationship between Mexican female politicians and policies created against violence exists"
+    },
+    "291": {
+        "sentence": "The Fifth Circuit earlier this month issued a highly unusual decision addressing whether state law could \"reverse preempt\" the New York Convention.",
+        "predicate": [
+            {
+                "str": "addressing",
+                "lemma": "address",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether state law could \"reverse preempt\" the New York Convention"
+    },
+    "292": {
+        "sentence": "If a resource is more than 75% busy for sustained periods, take a closer look to see whether or not that level of utilization is acceptable in terms of response time or queue length.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not that level of utilization is acceptable in terms of response time or queue length"
+    },
+    "293": {
+        "sentence": "We deny the right of such representation of the female members of the family, but granting this right, for argument's sake, it is very doubtful whether the one vote expresses the views and convictions of all the other members of the family.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "doubtful",
+                "lemma": "doubtful",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the one vote expresses the views and convictions of all the other members of the family"
+    },
+    "294": {
+        "sentence": "If you have a treatment center in mind you should contact them to determine whether or not they accept your insurance.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not they accept your insurance"
+    },
+    "295": {
+        "sentence": "Whether or not it casts those who were directly responsible in a negative light is irrelevant and, frankly, quite insignificant to the larger meaning attributed to the stories.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "irrelevant",
+                "lemma": "irrelevant",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "Whether or not it casts those who were directly responsible in a negative light"
+    },
+    "296": {
+        "sentence": "Whether the factory dumps each day is random (so not all factories are active every day, in fact, if all factories were active every day, we couldn't tease apart their signals).",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "random",
+                "lemma": "random",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "Whether the factory dumps each day"
+    },
+    "297": {
+        "sentence": "The court of protection decides whether an attorney who is acting under an existing of the lasting power of attorney should be removed or not.",
+        "predicate": [
+            {
+                "str": "decides",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether an attorney who is acting under an existing of the lasting power of attorney should be removed or not"
+    },
+    "298": {
+        "sentence": "Since both of these are part of the reasons why America is in trouble, the stability of a new America depends on whether or not they remain influential.",
+        "predicate": [
+            {
+                "str": "depends",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not they remain influential"
+    },
+    "299": {
+        "sentence": "That, along with the location, helps determine whether the owners would be content living in the given area for the long term.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the owners would be content living in the given area for the long term"
+    },
+    "300": {
+        "sentence": "We are still unclear as to whether or not Canada is a state.",
+        "predicate": [
+            {
+                "str": "are",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "unclear",
+                "lemma": "unclear",
+                "POS": "ADJ"
+            },
+            {
+                "str": "as",
+                "lemma": "as",
+                "POS": "ADP"
+            },
+            {
+                "str": "to",
+                "lemma": "to",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not Canada is a state"
+    },
+    "301": {
+        "sentence": "The lead researcher has now begun further experiments to determine whether this drug can be used to formulate new treatments.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether this drug can be used to formulate new treatments"
+    },
+    "302": {
+        "sentence": "I don't know whether I agree on the parents being unsupportive.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether I agree on the parents being unsupportive"
+    },
+    "303": {
+        "sentence": "Silly, since everybody have little bits about them that are different from most others, but it can be those very things that decide whether or not you're successful with a person.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not you're successful with a person"
+    },
+    "304": {
+        "sentence": "But, if the compounds that need to be separated remain colorless, it would be difficult to indicate whether you have obtained the desired compounds or not.",
+        "predicate": [
+            {
+                "str": "indicate",
+                "lemma": "indicate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you have obtained the desired compounds or not"
+    },
+    "305": {
+        "sentence": "If you need help with your online debt payment processing, or you're curious whether we can provide you with a more affordable alternative, you can always reach us here.",
+        "predicate": [
+            {
+                "str": "'re",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "curious",
+                "lemma": "curious",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether we can provide you with a more affordable alternative"
+    },
+    "306": {
+        "sentence": "As evidence of this, In Thomas de Quinceys Confessions of an English Opium-Eater (1821, p. 188), it is not Ottoman, nor Chinese addicts about whom he writes, But English opium users: \"I question whether any Turk, of all that ever entered the paradise of opium-eaters, can have had half the pleasure I had.\"",
+        "predicate": [
+            {
+                "str": "question",
+                "lemma": "question",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether any Turk, of all that ever entered the paradise of opium-eaters, can have had half the pleasure I had."
+    },
+    "307": {
+        "sentence": "Most studies using D-aspartic acid supplements did not report whether side effects occurred; long-term studies have not yet been performed using D-aspartic acid.",
+        "predicate": [
+            {
+                "str": "report",
+                "lemma": "report",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether side effects occurred"
+    },
+    "308": {
+        "sentence": "Further study is needed to determine whether it should be cycled.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether it should be cycled"
+    },
+    "309": {
+        "sentence": "This aims to help people understand whether they are saving enough for retirement and what they can do to make sure they are prepared for the future in terms of their job, money and health.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether they are saving enough for retirement"
+    },
+    "310": {
+        "sentence": "This aims to help people understand whether they are saving enough for retirement and what they can do to make sure they are prepared for the future in terms of their job, money and health.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "what they can do to make sure they are prepared for the future in terms of their job, money and health"
+    },
+    "311": {
+        "sentence": "This aims to help people understand whether they are saving enough for retirement and what they can do to make sure they are prepared for the future in terms of their job, money and health.",
+        "predicate": [
+            {
+                "str": "make",
+                "lemma": "make",
+                "POS": "VERB"
+            },
+            {
+                "str": "sure",
+                "lemma": "sure",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "declarative",
+        "clause": "they are prepared for the future in terms of their job, money and health"
+    },
+    "312": {
+        "sentence": "And these requirements do not reflect the complex and often messy realities of innovation, let alone capture whether the innovation has negative consequences, such as putting CFCs in refrigerators.",
+        "predicate": [
+            {
+                "str": "capture",
+                "lemma": "capture",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "the innovation has negative consequences, such as putting CFCs in refrigerators"
+    },
+    "313": {
+        "sentence": "A great deal of expertise has been developed around innovation surveys that ask firms whether they innovate, and in what forms.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether they innovate"
+    },
+    "314": {
+        "sentence": "A great deal of expertise has been developed around innovation surveys that ask firms whether they innovate, and in what forms.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "constituent",
+        "clause": "in what forms"
+    },
+    "315": {
+        "sentence": "We must consider upon the evidence before us whether the Germans of the first century held land in private ownership.",
+        "predicate": [
+            {
+                "str": "consider",
+                "lemma": "consider",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the Germans of the first century held land in private ownership"
+    },
+    "316": {
+        "sentence": "Once the affidavit and proposed order have been received by the court, a judge will consider all of the information you provided and determine whether you qualify for poor person status.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you qualify for poor person status"
+    },
+    "317": {
+        "sentence": "Sometimes the outcome in a student's life is not dependent on whether he/she studied at an Ivy League school.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "dependent",
+                "lemma": "dependent",
+                "POS": "ADJ"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether he/she studied at an Ivy League school"
+    },
+    "318": {
+        "sentence": "Marquette went test optional in June, allowing applicants to decide whether to include standardized test scores in their applications.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether to include standardized test scores in their applications"
+    },
+    "319": {
+        "sentence": "Our group of researchers and students considered whether there is a linear link between physical activity levels and mental health and whether sedentary habits, such as sitting all day, influenced this relationship.",
+        "predicate": [
+            {
+                "str": "considered",
+                "lemma": "consider",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether there is a linear link between physical activity levels and mental health"
+    },
+    "320": {
+        "sentence": "Our group of researchers and students considered whether there is a linear link between physical activity levels and mental health and whether sedentary habits, such as sitting all day, influenced this relationship.",
+        "predicate": [
+            {
+                "str": "considered",
+                "lemma": "consider",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether sedentary habits, such as sitting all day, influenced this relationship"
+    },
+    "321": {
+        "sentence": "During a conference call earlier this week, I asked the UNDR's Communications Chief William Orme whether \u201cglobal south was still a useful term.\"",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether \u201cglobal south was still a useful term"
+    },
+    "322": {
+        "sentence": "The Good Samaritan did not ask whether the man lying on the road had health insurance.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the man lying on the road had health insurance"
+    },
+    "323": {
+        "sentence": "But, unlike today, we did not immediately ask them whether we could withdraw food, water and antibiotics to get the death over with as soon as possible.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether we could withdraw food, water and antibiotics to get the death over with as soon as possible"
+    },
+    "324": {
+        "sentence": "But as yet, we still need to do more research before we can conclude with any certainty whether mixing by the marine biosphere is an important part of the ocean's circulation.",
+        "predicate": [
+            {
+                "str": "conclude",
+                "lemma": "conclude",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether mixing by the marine biosphere is an important part of the ocean's circulation"
+    },
+    "325": {
+        "sentence": "In the current research, Mouradian's team asked whether EHT and caffeine could work together for even greater brain protection.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether EHT and caffeine could work together for even greater brain protection"
+    },
+    "326": {
+        "sentence": "In essence, we just don't know whether the benefits of chest x-rays outweigh the harms (this is important and we'll come back to it later).",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the benefits of chest x-rays outweigh the harms"
+    },
+    "327": {
+        "sentence": "The president will decide in the next few hours whether or not he got enough of what he wanted.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not he got enough of what he wanted"
+    },
+    "328": {
+        "sentence": "The police searched this cabin in the caravan park and the owner gave them the address of the couple, but little more is known about this \u2014 and whether there is any information connecting Spedding to this cabin.",
+        "predicate": [
+            {
+                "str": "known",
+                "lemma": "know",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether there is any information connecting Spedding to this cabin"
+    },
+    "329": {
+        "sentence": "The police searched the dense bushland of Bonny Hills and Lake Cathie after other tip-offs, but again, it is unknown if there was anything found, and whether this was connected to Spedding.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "unknown",
+                "lemma": "unknown",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "if there was anything found"
+    },
+    "330": {
+        "sentence": "The police searched the dense bushland of Bonny Hills and Lake Cathie after other tip-offs, but again, it is unknown if there was anything found, and whether this was connected to Spedding.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "unknown",
+                "lemma": "unknown",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether this was connected to Spedding"
+    },
+    "331": {
+        "sentence": "This information regarding vehicles of interest was not made public knowledge until 12 months after the disappearance, and it is wondered whether an earlier public appeal could have helped the investigation significantly.",
+        "predicate": [
+            {
+                "str": "wondered",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether an earlier public appeal could have helped the investigation significantly"
+    },
+    "332": {
+        "sentence": "Although this is not the direction that investigators are moving forward with, it is crucial to establish whether this change of direction is justified.",
+        "predicate": [
+            {
+                "str": "establish",
+                "lemma": "establish",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether this change of direction is justified"
+    },
+    "333": {
+        "sentence": "Where #PeriodsOptional (women can decide whether or not to have periods and have access to the technology/medicine to do so) Where every child is planned (or at least not unwelcome) Where people are not judged by the clothes/shoes/makeup/hair they wear.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not to have periods"
+    },
+    "334": {
+        "sentence": "President Donald Trump is considering whether to pull out of the nuclear deal signed with Iran by his predecessor Barack Obama.",
+        "predicate": [
+            {
+                "str": "considering",
+                "lemma": "consider",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether to pull out of the nuclear deal signed with Iran by his predecessor Barack Obama"
+    },
+    "335": {
+        "sentence": "We can consider whether other specialists such as dermatologists may be needed in your treatment plan.",
+        "predicate": [
+            {
+                "str": "consider",
+                "lemma": "consider",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether other specialists such as dermatologists may be needed in your treatment plan"
+    },
+    "336": {
+        "sentence": "But nobody continued to question (as they once had) whether or not the internet was really necessary.",
+        "predicate": [
+            {
+                "str": "question",
+                "lemma": "question",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not the internet was really necessary"
+    },
+    "337": {
+        "sentence": "Organic acids testing is a way to measure whether your body is getting and using the nutrients needed for key metabolic processes.",
+        "predicate": [
+            {
+                "str": "measure",
+                "lemma": "measure",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether your body is getting and using the nutrients needed for key metabolic processes"
+    },
+    "338": {
+        "sentence": "We didn't want to worry about whether or not we'd have a paycheck every week.",
+        "predicate": [
+            {
+                "str": "worry",
+                "lemma": "worry",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not we'd have a paycheck every week"
+    },
+    "339": {
+        "sentence": "Such clustering, though, is not against any NCAA regulations, and it's not even clear whether, or how, the NCAA monitors clustering.",
+        "predicate": [
+            {
+                "str": "'s",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "clear",
+                "lemma": "clear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether"
+    },
+    "340": {
+        "sentence": "Such clustering, though, is not against any NCAA regulations, and it's not even clear whether, or how, the NCAA monitors clustering.",
+        "predicate": [
+            {
+                "str": "'s",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "clear",
+                "lemma": "clear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how, the NCAA monitors clustering"
+    },
+    "341": {
+        "sentence": "Given the transparent, barely perceptible nature of contact lenses, the first thing you should do is determine whether or not the lens is really still in your eye.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not the lens is really still in your eye"
+    },
+    "342": {
+        "sentence": "They will observe the way employees handle their mistakes to determine whether they will excel in their work environment.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether they will excel in their work environment"
+    },
+    "343": {
+        "sentence": "I still get confused as to whether I'm being selfish and in typing this comment I can actually feel myself looking for affirmation from you and other posters.",
+        "predicate": [
+            {
+                "str": "confused",
+                "lemma": "confuse",
+                "POS": "VERB"
+            },
+            {
+                "str": "as",
+                "lemma": "as",
+                "POS": "ADP"
+            },
+            {
+                "str": "to",
+                "lemma": "to",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether I'm being selfish"
+    },
+    "344": {
+        "sentence": "I still doubt at times whether I am making mountains out of mole hills.",
+        "predicate": [
+            {
+                "str": "doubt",
+                "lemma": "doubt",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether I am making mountains out of mole hills"
+    },
+    "345": {
+        "sentence": "Following a decision by the review panel, [plaintiff] will then decide whether or not to file a malpractice action.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not to file a malpractice action"
+    },
+    "346": {
+        "sentence": "LOS ANGELES (AP / FOX 11) - The bankruptcy of the Hanjin shipping line has thrown ports and retailers around the world into confusion, with giant container ships marooned and merchants worrying whether tons of goods will reach their shelves.",
+        "predicate": [
+            {
+                "str": "worrying",
+                "lemma": "worry",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether tons of goods will reach their shelves"
+    },
+    "347": {
+        "sentence": "However, unless you're deficient in calcium, which can lead to hair loss, there isn't enough clinical evidence to say whether or not supplementation will provide any hair benefits.",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not supplementation will provide any hair benefits"
+    },
+    "348": {
+        "sentence": "No Zones (significant blind spots) can make it difficult for a truck driver to tell whether a lane is clear before merging.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a lane is clear before merging"
+    },
+    "349": {
+        "sentence": "A Dallas spinal cord injury lawyer can help truck accident victims recognize whether or not someone else is liable for damages after a serious spinal cord injury.",
+        "predicate": [
+            {
+                "str": "recognize",
+                "lemma": "recognize",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not someone else is liable for damages after a serious spinal cord injury"
+    },
+    "350": {
+        "sentence": "If a truck driver caused a serious accident or wrongful death, an accident attorney can most likely discover whether he or she cheated on the logbooks.",
+        "predicate": [
+            {
+                "str": "discover",
+                "lemma": "discover",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether he or she cheated on the logbooks"
+    },
+    "351": {
+        "sentence": "So if a trader has an interest in a particular offer, he must find out whether his broker offers that or not.",
+        "predicate": [
+            {
+                "str": "find",
+                "lemma": "find",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether his broker offers that or not"
+    },
+    "352": {
+        "sentence": "The parents of a teenager who was forced to leave a specialist school that supports children with severe autism in Bristol are investigating whether they can sue the education watchdog.",
+        "predicate": [
+            {
+                "str": "investigating",
+                "lemma": "investigate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether they can sue the education watchdog"
+    },
+    "353": {
+        "sentence": "The problem was this: I had a hard time caring about whether or not Jon Snow was alive, when I knew that, for sure, Prince was dead.",
+        "predicate": [
+            {
+                "str": "caring",
+                "lemma": "care",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not Jon Snow was alive"
+    },
+    "354": {
+        "sentence": "Why watch Game of Thrones, I thought to myself, why spend a minute caring about the fate of a stompy pious crow, why spend a second wondering about whether or not Melisandre was going to nudely revive him with the vampish machinations this show sometimes uses as a stand in for sex, when you could be listening to Purple Rain?",
+        "predicate": [
+            {
+                "str": "wondering",
+                "lemma": "wonder",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not Melisandre was going to nudely revive him with the vampish machinations this show sometimes uses as a stand in for sex"
+    },
+    "355": {
+        "sentence": "Because ART is so effective at reducing viral load, without the randomized control group of participants taking ART alone to compare against, we couldn't have been so confident in knowing whether the kick and kill drugs had made any impact.",
+        "predicate": [
+            {
+                "str": "knowing",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the kick and kill drugs had made any impact."
+    },
+    "356": {
+        "sentence": "I loved thinking about whether or not penguins even dream, and that thought sparked a long conversation.",
+        "predicate": [
+            {
+                "str": "thinking",
+                "lemma": "think",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not penguins even dream"
+    },
+    "357": {
+        "sentence": "The investigation is still ongoing, so it's not clear whether coverage under the Occupational Health and Safety Act could have prevented Adam's death, but it's telling, however, that the investigation is being led by the Niagara Regional Police Service because the Ministry of Labour does not have jurisdiction over occupational health and safety issues related to unpaid work.",
+        "predicate": [
+            {
+                "str": "'s",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "clear",
+                "lemma": "clear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether coverage under the Occupational Health and Safety Act could have prevented Adam's death"
+    },
+    "358": {
+        "sentence": "The investigation is still ongoing, so it's not clear whether coverage under the Occupational Health and Safety Act could have prevented Adam's death, but it's telling, however, that the investigation is being led by the Niagara Regional Police Service because the Ministry of Labour does not have jurisdiction over occupational health and safety issues related to unpaid work.",
+        "predicate": [
+            {
+                "str": "'s",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "telling",
+                "lemma": "telling",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that the investigation is being led by the Niagara Regional Police Service"
+    },
+    "359": {
+        "sentence": "The people in the business need to know whether or not they can survive, whether there's a business case for them to be able to survive.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not they can survive"
+    },
+    "360": {
+        "sentence": "The people in the business need to know whether or not they can survive, whether there's a business case for them to be able to survive.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether there's a business case for them to be able to survive"
+    },
+    "361": {
+        "sentence": "It is doubtful whether the strategy will be successful.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "doubtful",
+                "lemma": "doubtful",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the strategy will be successful"
+    },
+    "362": {
+        "sentence": "In early May, another retired SFPD officer contacted The Chronicle, asking whether reporters had heard of Building 606.",
+        "predicate": [
+            {
+                "str": "asking",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether reporters had heard of Building 606"
+    },
+    "363": {
+        "sentence": "Next steps in the research involve analyzing whether species that have longer lifespans than humans--like the bowhead whale, which can live more than 200 years--have evolved even more robust SIRT6 genes.",
+        "predicate": [
+            {
+                "str": "analyzing",
+                "lemma": "analyze",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether species that have longer lifespans than humans--like the bowhead whale, which can live more than 200 years--have evolved even more robust SIRT6 genes"
+    },
+    "364": {
+        "sentence": "The court is not being asked to make a ruling on the substance of the Kenyans' allegations but to decide whether a fair trial can be held so long after the events.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a fair trial can be held so long after the events"
+    },
+    "365": {
+        "sentence": "Therefore, those who have not received the overtime pay they are entitled to may want to learn more about whether they are able to recover that compensation through a wage and hour claim.",
+        "predicate": [
+            {
+                "str": "learn",
+                "lemma": "learn",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether they are able to recover that compensation through a wage and hour claim"
+    },
+    "366": {
+        "sentence": "Now Italy's courts are fighting over whether a barbaric Sicilian capo should get the right to die with dignity.",
+        "predicate": [
+            {
+                "str": "fighting",
+                "lemma": "fight",
+                "POS": "VERB"
+            },
+            {
+                "str": "over",
+                "lemma": "over",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a barbaric Sicilian capo should get the right to die with dignity"
+    },
+    "367": {
+        "sentence": "When you start to doubt yourself and your own mind, it may be time to look into whether you are in an abusive relationship with a \u201ccrazy maker\u009d.\"",
+        "predicate": [
+            {
+                "str": "look",
+                "lemma": "look",
+                "POS": "VERB"
+            },
+            {
+                "str": "into",
+                "lemma": "into",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you are in an abusive relationship with a \u201ccrazy maker\u009d"
+    },
+    "368": {
+        "sentence": "They'll tell you all about this, and whether they have any charges, when you first contact them.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether they have any charges"
+    },
+    "369": {
+        "sentence": "Then the group, the Molecular Tumor Board (MTB), decides whether to send cases out for genetic sequencing to help identify a new course of action.",
+        "predicate": [
+            {
+                "str": "decides",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether to send cases out for genetic sequencing to help identify a new course of action"
+    },
+    "370": {
+        "sentence": "There's a very arbitrary 48-hour deadline imposed by Michael's boss, forcing Michael to decide whether he wants to try to make a go of it with Jane in Miami.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether he wants to try to make a go of it with Jane in Miami"
+    },
+    "371": {
+        "sentence": "Doctors and medical malpractice insurance companies currently must live with this 'bad outcome' ruling, although it is often unknown whether a better outcome was possible.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "unkown",
+                "lemma": "unkown",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a better outcome was possible"
+    },
+    "372": {
+        "sentence": "To help you know whether your cheerleading youngsters are protected from unreasonable risk, the AACA advises talking to the school's cheerleading coach about safety.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether your cheerleading youngsters are protected from unreasonable risk"
+    },
+    "373": {
+        "sentence": "Juveniles too often are questioned by police and enter guilty pleas in court without a lawyer and have no one to investigate their case or understand whether a plea disposition is appropriate, said Kim Dvorchak, executive director of NJDC.",
+        "predicate": [
+            {
+                "str": "understand",
+                "lemma": "understand",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a plea disposition is appropriate"
+    },
+    "374": {
+        "sentence": "Those of us in New Jersey can support the adoption of Senate Bill 677, sponsored by Sen. Ronald L. Rice, which would require our legislature to issue racial impact statements to assess whether proposed legislation will have a disproportionate racial impact.",
+        "predicate": [
+            {
+                "str": "assess",
+                "lemma": "assess",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether proposed legislation will have a disproportionate racial impact"
+    },
+    "375": {
+        "sentence": "With the country's departure set for March 29, it remains unclear whether British lawmakers will approve the divorce deal the government negotiated with the EU.",
+        "predicate": [
+            {
+                "str": "remains",
+                "lemma": "remain",
+                "POS": "VERB"
+            },
+            {
+                "str": "unclear",
+                "lemma": "unclear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether British lawmakers will approve the divorce deal the government negotiated with the EU"
+    },
+    "376": {
+        "sentence": "The Washington State Transportation Commission will propose toll increases for the Tacoma Narrows Bridge Tuesday, and the amount will hinge on whether it wants a big reserve fund.",
+        "predicate": [
+            {
+                "str": "hinge",
+                "lemma": "hinge",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether it wants a big reserve fund"
+    },
+    "377": {
+        "sentence": "The way the process works, the Transportation Commission views the citizen group's recommendation as the low point, discusses whether it's enough, but usually accepts it or inches it up.",
+        "predicate": [
+            {
+                "str": "discusses",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether it's enough"
+    },
+    "378": {
+        "sentence": "If ICE shows up on a worksite on a \u201ctip\"\u009d\u2013 without a warrant \u2013 then it's up to the employer to decide whether to let ICE inspect the premises.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether to let ICE inspect the premises"
+    },
+    "379": {
+        "sentence": "They did not realize whether this man was a devil or not.",
+        "predicate": [
+            {
+                "str": "realize",
+                "lemma": "realize",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether this man was a devil or not"
+    },
+    "380": {
+        "sentence": "The economy may be improving slightly but, perhaps more importantly, the other guys are talking about restricting the accessibility of birth control or whether or not women should be in the workplace or the extent to which the devil has infiltrated American institutions among other crazy things.",
+        "predicate": [
+            {
+                "str": "talking",
+                "lemma": "talk",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not women should be in the workplace"
+    },
+    "381": {
+        "sentence": "Measuring whether the segments' amount of existing space is sufficient and appropriate is difficult.",
+        "predicate": [
+            {
+                "str": "Measuring",
+                "lemma": "measure",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the segments' amount of existing space is sufficient and appropriate"
+    },
+    "382": {
+        "sentence": "It doesnt care and couldnt care whether you have to get up early to go to work and that waking up at 3:00 a.m. to answer its demand for food is not very considerate of it.",
+        "predicate": [
+            {
+                "str": "care",
+                "lemma": "care",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you have to get up early to go to work"
+    },
+    "383": {
+        "sentence": "It doesnt care and couldnt care whether you have to get up early to go to work and that waking up at 3:00 a.m. to answer its demand for food is not very considerate of it.",
+        "predicate": [
+            {
+                "str": "care",
+                "lemma": "care",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that waking up at 3:00 a.m. to answer its demand for food is not very considerate of it"
+    },
+    "384": {
+        "sentence": "\"Because of (this) the brain scientists have begun to wonder whether our normal feeling of being one person is also an illusion, even though our brains remain whole.",
+        "predicate": [
+            {
+                "str": "wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether our normal feeling of being one person is also an illusion, even though our brains remain whole"
+    },
+    "385": {
+        "sentence": "But beware, the availability of money will depend on whether the day is work or not and if your bank is part of the entities with which Single credits works.",
+        "predicate": [
+            {
+                "str": "depend",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the day is work or not"
+    },
+    "386": {
+        "sentence": "But beware, the availability of money will depend on whether the day is work or not and if your bank is part of the entities with which Single credits works.",
+        "predicate": [
+            {
+                "str": "depend",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "if your bank is part of the entities with which Single credits works"
+    },
+    "387": {
+        "sentence": "Just some more head fakes on the birth issue and some whining from Crowley about not getting to see whether he took economics at Columbia.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether he took economics at Columbia"
+    },
+    "388": {
+        "sentence": "Psychologists based at University College London and Exeter University are testing whether a one-off dose of the drug could help hazardous drinkers who are trying to reduce their alcohol intake.",
+        "predicate": [
+            {
+                "str": "testing",
+                "lemma": "test",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a one-off dose of the drug could help hazardous drinkers who are trying to reduce their alcohol intake"
+    },
+    "389": {
+        "sentence": "The team will follow up the people for a year and monitor whether their drinking has changed and by how much.",
+        "predicate": [
+            {
+                "str": "monitor",
+                "lemma": "monitor",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether their drinking has changed"
+    },
+    "390": {
+        "sentence": "Feasibility: in this phase the organisers evaluate whether a foresight exercise is appropriate given the context and whether it will be able to yield valuable impacts on the system addressed.",
+        "predicate": [
+            {
+                "str": "evaluate",
+                "lemma": "evaluate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether a foresight exercise is appropriate given the context"
+    },
+    "391": {
+        "sentence": "Feasibility: in this phase the organisers evaluate whether a foresight exercise is appropriate given the context and whether it will be able to yield valuable impacts on the system addressed.",
+        "predicate": [
+            {
+                "str": "evaluate",
+                "lemma": "evaluate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether it will be able to yield valuable impacts on the system addressed"
+    },
+    "392": {
+        "sentence": "We don't know whether Zimphos is meeting air quality control standards.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether Zimphos is meeting air quality control standards"
+    },
+    "393": {
+        "sentence": "The church was rebuilt after an earthquake in 1805, but the town suffered heavy damage in World War II, and it is not known whether the traditional local practices have survived to this day.",
+        "predicate": [
+            {
+                "str": "known",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the traditional local practices have survived to this day"
+    },
+    "394": {
+        "sentence": "It is not known whether this piece, dating from the 1st century, is actually on display, as it might be considered offensive or even blasphemous.",
+        "predicate": [
+            {
+                "str": "known",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether this piece, dating from the 1st century, is actually on display"
+    },
+    "395": {
+        "sentence": "As for presidential front-runner Andr\u00c3\u00a9s Manuel L\u00c3\u00b3pez Obrador (AMLO), he may do better than expected \u2014 it will all depend on whether the electorate believes he can improve the security situation.",
+        "predicate": [
+            {
+                "str": "depend",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the electorate believes he can improve the security situation"
+    },
+    "396": {
+        "sentence": "As for presidential front-runner Andr\u00c3\u00a9s Manuel L\u00c3\u00b3pez Obrador (AMLO), he may do better than expected \u2014 it will all depend on whether the electorate believes he can improve the security situation.",
+        "predicate": [
+            {
+                "str": "believes",
+                "lemma": "believe",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "he can improve the security situation"
+    },
+    "397": {
+        "sentence": "But now the beautiful actress broke the silence and revealed whether she is indeed succumbed to his charm.",
+        "predicate": [
+            {
+                "str": "revealed",
+                "lemma": "reveal",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether she is indeed succumbed to his charm"
+    },
+    "398": {
+        "sentence": "We're not sure whether pollsters were referring to Los Stop's version, Con su blanca palidez, though somehow we suspect not.",
+        "predicate": [
+            {
+                "str": "'re",
+                "lemma": "be",
+                "POS": "VERB"
+            },
+            {
+                "str": "sure",
+                "lemma": "sure",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether pollsters were referring to Los Stop's version, Con su blanca palidezs"
+    },
+    "399": {
+        "sentence": "His Bachelor thesis was titled \"Journalism & Trauma\", in which he wanted to examine whether German editorial offices are preparing their war correspondents sufficiently for their operations abroad.",
+        "predicate": [
+            {
+                "str": "examine",
+                "lemma": "examine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether German editorial offices are preparing their war correspondents sufficiently for their operations abroad"
+    },
+    "400": {
+        "sentence": "The scientists in New Zealand want to expand their study to find out whether other insect species worldwide transfer LHUV-1 and, if so, which ones.",
+        "predicate": [
+            {
+                "str": "find",
+                "lemma": "find",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether other insect species worldwide transfer LHUV-1"
+    },
+    "401": {
+        "sentence": "The scientists in New Zealand want to expand their study to find out whether other insect species worldwide transfer LHUV-1 and, if so, which ones.",
+        "predicate": [
+            {
+                "str": "find",
+                "lemma": "find",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "which ones"
+    },
+    "402": {
+        "sentence": "If the thought of only having a one glass of wine, on special occasions makes you nervous, perhaps you need to wonder whether or not alcohol is something that you are using as a coping mechanism, rather than something that you are choosing to enjoy for pleasure.",
+        "predicate": [
+            {
+                "str": "wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not alcohol is something that you are using as a coping mechanism, rather than something that you are choosing to enjoy for pleasure."
+    },
+    "403": {
+        "sentence": "Al Hamili remained non-committal on whether or not Opec would increase output in view of the of the current market volatility.",
+        "predicate": [
+            {
+                "str": "remained",
+                "lemma": "remain",
+                "POS": "VERB"
+            },
+            {
+                "str": "non-committal",
+                "lemma": "non-committal",
+                "POS": "ADJ"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not Opec would increase output in view of the of the current market volatility"
+    },
+    "404": {
+        "sentence": "This article is a few years old, but a friend sent it to me asking whether it's an accurate description of living as a writer in New Orleans.",
+        "predicate": [
+            {
+                "str": "asking",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether it's an accurate description of living as a writer in New Orleans"
+    },
+    "405": {
+        "sentence": "Attorneys also look into whether or not a company's protocols were followed and how this affected the situation.",
+        "predicate": [
+            {
+                "str": "look",
+                "lemma": "look",
+                "POS": "VERB"
+            },
+            {
+                "str": "into",
+                "lemma": "into",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not a company's protocols were followed"
+    },
+    "406": {
+        "sentence": "Attorneys also look into whether or not a company's protocols were followed and how this affected the situation.",
+        "predicate": [
+            {
+                "str": "look",
+                "lemma": "look",
+                "POS": "VERB"
+            },
+            {
+                "str": "into",
+                "lemma": "into",
+                "POS": "ADP"
+            }
+        ],
+        "type": "constituent",
+        "clause": "how this affected the situation"
+    },
+    "407": {
+        "sentence": "The Board members who were aware of the article should have inquired further about Sandusky and the possible risks of litigation or public relations issues, and, most importantly, whether the University has effective policies in place to protect children on its campuses.",
+        "predicate": [
+            {
+                "str": "inquired",
+                "lemma": "inquire",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the University has effective policies in place to protect children on its campuses"
+    },
+    "408": {
+        "sentence": "For this, the Commission will also assess whether the law provides for a balance between the promotion of Ukrainian and guarantees for minority languages.",
+        "predicate": [
+            {
+                "str": "assess",
+                "lemma": "assess",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the law provides for a balance between the promotion of Ukrainian and guarantees for minority languages"
+    },
+    "409": {
+        "sentence": "But as an aside, I'm also hesitant as to whether we can really say that Jesus and people of his time were ethnically egalitarian in our modern sense.",
+        "predicate": [
+            {
+                "str": "hesitant",
+                "lemma": "hesitant",
+                "POS": "ADJ"
+            },
+            {
+                "str": "as",
+                "lemma": "as",
+                "POS": "ADP"
+            },
+            {
+                "str": "to",
+                "lemma": "to",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether we can really say that Jesus and people of his time were ethnically egalitarian in our modern sense"
+    },
+    "410": {
+        "sentence": "But as an aside, I'm also hesitant as to whether we can really say that Jesus and people of his time were ethnically egalitarian in our modern sense.",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that Jesus and people of his time were ethnically egalitarian in our modern sense"
+    },
+    "411": {
+        "sentence": "A systematic assessment of the content of aristolochic acids in the most widely used species is needed to evaluate whether their uses pose a potential health risk.",
+        "predicate": [
+            {
+                "str": "evaluate",
+                "lemma": "evaluate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether their uses pose a potential health risk"
+    },
+    "412": {
+        "sentence": "In China and Europe species of Aristolochia have been associated with nephropathy and it is important to evaluate whether nephropathy occurs in other parts of the world, especially India and Central America where the use of species of Aristolochia are reported to be commonly used in traditional medicine.",
+        "predicate": [
+            {
+                "str": "evaluate",
+                "lemma": "evaluate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether nephropathy occurs in other parts of the world, especially India and Central America where the use of species of Aristolochia are reported to be commonly used in traditional medicine"
+    },
+    "413": {
+        "sentence": "With such a range of outcomes, it is fair to ask whether you need a personal injury lawyer after a car accident.",
+        "predicate": [
+            {
+                "str": "ask",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you need a personal injury lawyer after a car accident"
+    },
+    "414": {
+        "sentence": "Seeing a doctor after the accident can help determine whether you have one of these types of injuries.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you have one of these types of injuries"
+    },
+    "415": {
+        "sentence": "We think about whether that wheel was a good buy.",
+        "predicate": [
+            {
+                "str": "think",
+                "lemma": "think",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether that wheel was a good buy"
+    },
+    "416": {
+        "sentence": "For example, in deciding whether to grant a nonimmigrant visa, the USCIS will determine whether the applicant truly intends to return to his or her country when the visa expires.",
+        "predicate": [
+            {
+                "str": "deciding",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether to grant a nonimmigrant visa"
+    },
+    "417": {
+        "sentence": "For example, in deciding whether to grant a nonimmigrant visa, the USCIS will determine whether the applicant truly intends to return to his or her country when the visa expires.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the applicant truly intends to return to his or her country when the visa expires"
+    },
+    "418": {
+        "sentence": "Personal taste will dictate whether you find it wonderful or not, but I seriously doubt you'll enjoy it as much as the holiday classic that the narrator alludes to.",
+        "predicate": [
+            {
+                "str": "dictate",
+                "lemma": "dictate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you find it wonderful or not"
+    },
+    "419": {
+        "sentence": "Personal taste will dictate whether you find it wonderful or not, but I seriously doubt you'll enjoy it as much as the holiday classic that the narrator alludes to.",
+        "predicate": [
+            {
+                "str": "doubt",
+                "lemma": "doubt",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "you'll enjoy it as much as the holiday classic that the narrator alludes to"
+    },
+    "420": {
+        "sentence": "I am trying to scout whether the Chairperson is here.",
+        "predicate": [
+            {
+                "str": "scout",
+                "lemma": "scout",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the Chairperson is here"
+    },
+    "421": {
+        "sentence": "Temporary Speaker, Sir, I would like the Chairperson to state:- (a) Whether he is aware that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter.",
+        "predicate": [
+            {
+                "str": "state",
+                "lemma": "state",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "Whether he is aware that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter"
+    },
+    "422": {
+        "sentence": "Temporary Speaker, Sir, I would like the Chairperson to state:- (a) Whether he is aware that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "aware",
+                "lemma": "aware",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that guidelines provided by the Government on how much fees public schools should charge are not followed to the letter"
+    },
+    "423": {
+        "sentence": "I do not know whether I am the only one who heard my good friend, the simba from Kirinyaga mention that some\"\u009d.\"",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether I am the only one who heard my good friend, the simba from Kirinyaga mention that some\"\u009d.\""
+    },
+    "424": {
+        "sentence": "I do not know whether I am the only one who heard my good friend, the simba from Kirinyaga mention that some\"\u009d.\"",
+        "predicate": [
+            {
+                "str": "mention",
+                "lemma": "mention",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that some\"\u009d.\""
+    },
+    "425": {
+        "sentence": "The course analyzes the criteria for determining whether or not a particular promise or voluntary agreement is legally enforceable and surveys the major legal issues affecting enforceable agreements.",
+        "predicate": [
+            {
+                "str": "determining",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not a particular promise or voluntary agreement is legally enforceable"
+    },
+    "426": {
+        "sentence": "But when asked whether early, pre-album hits \u2014 like \u2018Sweater' and \u2018Turn Up Your Stereo' \u2014 ever make an appearance on live set lists, Kav shudders.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether early, pre-album hits \u2014 like \u2018Sweater' and \u2018Turn Up Your Stereo' \u2014 ever make an appearance on live set lists"
+    },
+    "427": {
+        "sentence": "Whether, in a case of such collaboration between state and federal officers, the defendant could successfully assert his privilege in the state proceeding, we need not now decide, for the record before us is barren of evidence that the State was used as an instrument of federal prosecution or investigation.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "Whether, in a case of such collaboration between state and federal officers, the defendant could successfully assert his privilege in the state proceeding"
+    },
+    "428": {
+        "sentence": "Talk to your doctor to see if taking antidepressants can help to reduce your symptoms of atheophobia, as well as whether or not it is safe to do so.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "if taking antidepressants can help to reduce your symptoms of atheophobia"
+    },
+    "429": {
+        "sentence": "Talk to your doctor to see if taking antidepressants can help to reduce your symptoms of atheophobia, as well as whether or not it is safe to do so.",
+        "predicate": [
+            {
+                "str": "see",
+                "lemma": "see",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether or not it is safe to do so"
+    },
+    "430": {
+        "sentence": "Willis therefore called on several Bulgarian ministers and they agreed to consider whether to renew the offer.",
+        "predicate": [
+            {
+                "str": "consider",
+                "lemma": "consider",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether to renew the offer"
+    },
+    "431": {
+        "sentence": "The Foreign Office followed this up and the Office of Works asked the Treasury whether, if a new site was offered, it would support building a new house on it for the agent and consul-general.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether, if a new site was offered, it would support building a new house on it for the agent and consul-general"
+    },
+    "432": {
+        "sentence": "I question whether any of this is really possible today, though.",
+        "predicate": [
+            {
+                "str": "question",
+                "lemma": "question",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether any of this is really possible today"
+    },
+    "433": {
+        "sentence": "The Ministry will then decide whether the relevant facility's impact on the environment is acceptable within the framework of the applicable legislation.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether the relevant facility's impact on the environment is acceptable within the framework of the applicable legislation"
+    },
+    "434": {
+        "sentence": "For activities within the scope of Annex II of the EIA Regulation (projects subject to election and assessment criteria), an EIA presentation file must be submitted to the Ministry or the relevant authority, who will then assess whether preparation of an EIA report is required for the specific project.",
+        "predicate": [
+            {
+                "str": "assess",
+                "lemma": "assess",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether preparation of an EIA report is required for the specific project"
+    },
+    "435": {
+        "sentence": "Hyperion, it was awesome, but a warning that the first few pages are pretty lack-lustre and cliche sci-fi-ish so I nearly gave up on it (and friends have had the same experience) \u2014 but once it hits the first tale (the priest's tale) it starts to get really intriguing and compelling and not cliche ... So I'd suggest waiting till you get into that before deciding whether to persist.",
+        "predicate": [
+            {
+                "str": "deciding",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether to persist"
+    },
+    "436": {
+        "sentence": "There are a number of quizzes and symptom checkers online that you can use to try to determine whether you have anxiety.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "polar",
+        "clause": "whether you have anxiety"
+    }, 
+    "437": {
+        "sentence": "The first case study analyzes whether female PRI Senator Diva Gastelum represents her constituents through descriptive or substantives representation.",
+        "predicate": [
+            {
+                "str": "analyzes",
+                "lemma": "analyze",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether female PRI Senator Diva Gastelum represents her constituents through descriptive or substantives representation"
+    },
+    "438": {
+        "sentence": "The best example of this is her often touted masterpiece, The Rising of the Moon (1945), which is narrated by a 13-year-old boy and is better read as a coming-of-age story with strong mystery elements than as a pure detective story \u2013 because the ending leaves you scratching your head in utter amazement (it's up to the individual reader to decide whether that's a good thing or a bad thing).",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether that's a good thing or a bad thing"
+    },
+    "439": {
+        "sentence": "Whether a molecular configuration is designated E or Z is determined by the Cahn-Ingold-Prelog priority rules; higher atomic numbers are given higher priority.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "Whether a molecular configuration is designated E or Z"
+    },
+    "440": {
+        "sentence": "Whether the \u2018drop\u2019 of the record reverberates on a micro-scale, or to Grand Canyon echo-type proportions, you can never know.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "Whether the \u2018drop\u2019 of the record reverberates on a micro-scale, or to Grand Canyon echo-type proportions"
+    },
+    "441": {
+        "sentence": "Different weights are assigned to the words based on whether they appear in the title, subheadings or the body of the page and the number of times a particular word appears in the webpage is stored.",
+        "predicate": [
+            {
+                "str": "based",
+                "lemma": "base",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether they appear in the title, subheadings or the body of the page"
+    },
+    "442": {
+        "sentence": "* FIFA members will decide on Wednesday (June 13) whether the 2026 World Cup should be played in North America or return to Africa for just the second time, in Morocco.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the 2026 World Cup should be played in North America or return to Africa for just the second time, in Morocco"
+    },
+    "443": {
+        "sentence": "Ultimately, only I get to determine whether I am a victim, a villain, or a victor.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether I am a victim, a villain, or a victor"
+    },
+    "444": {
+        "sentence": "Last season he was basically a training cone, not knowing whether to engage his opponent or stand off.",
+        "predicate": [
+            {
+                "str": "knowing",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to engage his opponent or stand off"
+    },
+    "445": {
+        "sentence": "On February 3rd, Kaplan will decide whether Rocco must return to New York, and his mother, or whether he can stay in London with his father.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Rocco must return to New York, and his mother, or whether he can stay in London with his father"
+    },
+    "446": {
+        "sentence": "Whether a person is \u2018male\u2019 or \u2018female\u2019 is not defined by testosterone levels, and there are no non-arbitrary definitions of testosterone levels that would make a person one of the other.",
+        "predicate": [
+            {
+                "str": "defined",
+                "lemma": "define",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "Whether a person is \u2018male\u2019 or \u2018female\u2019"
+    },
+    "447": {
+        "sentence": "We must decide whether this exception applies only to insurance company boycotts of agents and other companies or also applies to refusals to deal with policyholders.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether this exception applies only to insurance company boycotts of agents and other companies or also applies to refusals to deal with policyholders"
+    },
+    "448": {
+        "sentence": "(Whether the management (M) answered the question or the works council (WC) is illustrated in brackets.)",
+        "predicate": [
+            {
+                "str": "illustrated",
+                "lemma": "illustrate",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "Whether the management (M) answered the question or the works council (WC)"
+    },
+    "449": {
+        "sentence": "Count Dracula (Gary Oldman, I mean \u2013 but these days he looks as old as his make up made him appear in Dracula\u2026)is bit of a clichee, and the female lead at the end wants so much to look like Sarah Connor that it is almost confusing whether she will next have a baby with Arnold Schwarzenegger or go and kill the bad guys.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "confusing",
+                "lemma": "confusing",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether she will next have a baby with Arnold Schwarzenegger or go and kill the bad guys"
+    },
+    "450": {
+        "sentence": "Firstly by seeing one of our trained Doctors we can determine whether this is Allergic Contact Dermatitis or another rash by the pattern of the rash and history.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether this is Allergic Contact Dermatitis or another rash"
+    },
+    "451": {
+        "sentence": "My treatments are covered by worker's compensation, however, to get what I need takes months of fighting with them about whether the issue at hand has anything to do with a TBI or is even related to the assault at all.",
+        "predicate": [
+            {
+                "str": "fighting",
+                "lemma": "fight",
+                "POS": "VERB"
+            },
+            {
+                "str": "about",
+                "lemma": "about",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the issue at hand has anything to do with a TBI or is even related to the assault at all"
+    },
+    "452": {
+        "sentence": "Whether a neo-con or a progressive acts in the theater of globalization is ultimately irrelevant.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "irrelevant",
+                "lemma": "irrelevant",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "Whether a neo-con or a progressive acts in the theater of globalization"
+    },
+    "453": {
+        "sentence": "It doesn\u2019t matter whether its work, family, or friends, good morals will get you a long way with people, and they will respect you for it!",
+        "predicate": [
+            {
+                "str": "matter",
+                "lemma": "matter",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether its work, family, or friends"
+    },
+    "454": {
+        "sentence": "After Liberation in November 1944 the Albanian people had to decide whether to return to an almost feudal structure, welcome back the cowardly Zog or attempt to build a new society based on Communist principles.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to return to an almost feudal structure, welcome back the cowardly Zog or attempt to build a new society based on Communist principles"
+    },
+    "455": {
+        "sentence": "So as long as everyone would be exposed to STEM and be able to choose it as a career to pursue without pressure to not do so, it doens't matter to me whether it's 50/50, 60/40 or 70/30.",
+        "predicate": [
+            {
+                "str": "matter",
+                "lemma": "matter",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether it's 50/50, 60/40 or 70/30"
+    },
+    "456": {
+        "sentence": "You know whether it\u2019s in the Bay Area or in the Northeast or in all the places up the Pacific Northwest.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether it\u2019s in the Bay Area or in the Northeast or in all the places up the Pacific Northwest"
+    },
+    "457": {
+        "sentence": "No one is certain whether Betty is still alive or just hypnotized, but the dreamy look on her face would seem to confirm her deep love for TV dramas.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "certain",
+                "lemma": "certain",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Betty is still alive or just hypnotized"
+    },
+    "458": {
+        "sentence": "A meeting with the zoning department will study the existing traffic patterns and parking and let the owner know whether existing conditions are sufficient or if additional parking, turn lanes, or even a traffic light will be necessary to keep the clientele happy and allow them to come and go in a safe manner.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether existing conditions are sufficient or if additional parking, turn lanes, or even a traffic light will be necessary to keep the clientele happy and allow them to come and go in a safe manner"
+    },
+    "459": {
+        "sentence": "It remains ambiguous whether Helen\u2019s rejection of her sexual habits is feigned, or whether it represents a brief moment of sincerity, the realization that having many short-lived affairs with men does not necessarily bring her (or her daughter) happiness and stability.",
+        "predicate": [
+            {
+                "str": "remains",
+                "lemma": "remain",
+                "POS": "VERB"
+            },
+            {
+                "str": "ambiguous",
+                "lemma": "ambiguous",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Helen\u2019s rejection of her sexual habits is feigned, or whether it represents a brief moment of sincerity, the realization that having many short-lived affairs with men does not necessarily bring her (or her daughter) happiness and stability"
+    },
+    "460": {
+        "sentence": "He wonders whether reality is a dream or dreams reality.",
+        "predicate": [
+            {
+                "str": "wonders",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether reality is a dream or dreams reality"
+    },
+    "461": {
+        "sentence": "If you can't decide whether you prefer dramatic coastline or heather moorland then the 109 mile long Cleveland Way is your perfect trail.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether you prefer dramatic coastline or heather moorland"
+    },
+    "462": {
+        "sentence": "At the post-secondary level, students fall into four categories, depending on whether their work placement is paid or unpaid, and whether their work placement is optional or a mandatory requirement for graduation.",
+        "predicate": [
+            {
+                "str": "depending",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether their work placement is paid or unpaid"
+    },
+    "463": {
+        "sentence": "At the post-secondary level, students fall into four categories, depending on whether their work placement is paid or unpaid, and whether their work placement is optional or a mandatory requirement for graduation.",
+        "predicate": [
+            {
+                "str": "depending",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether their work placement is optional or a mandatory requirement for graduation"
+    },
+    "464": {
+        "sentence": "No mainstream political party and no prominent politician is fighting publicly to reveal whether the accumulated evidence indicates failures of policy or represents an unconnected sequence of criminal actions by a tiny minority of rogue soldiers.",
+        "predicate": [
+            {
+                "str": "reveal",
+                "lemma": "reveal",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the accumulated evidence indicates failures of policy or represents an unconnected sequence of criminal actions by a tiny minority of rogue soldiers"
+    },
+    "465": {
+        "sentence": "University of Toronto, Department of Sociology (Toronto, Canada): The Faculty of Arts and Science has instituted a funding guarantee that covers PhD students for four or five years (depending on whether the student enters directly from a BA, or completes an MA before entering the program).",
+        "predicate": [
+            {
+                "str": "depending",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the student enters directly from a BA, or completes an MA before entering the program"
+    },
+    "466": {
+        "sentence": "Ultimately, whether to bootstrap or finance depends on all of the factors identified in this article, if not more.",
+        "predicate": [
+            {
+                "str": "depends",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to bootstrap or finance"
+    },
+    "467": {
+        "sentence": "The type of mortgage you are able to apply for will depend on whether you want to repay interest only or interest and capital.",
+        "predicate": [
+            {
+                "str": "depend",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether you want to repay interest only or interest and capital"
+    },
+    "468": {
+        "sentence": "Currently, however, high school athletic associations in each state in the U.S. decide whether cheerleading is considered a sport or treated as a club activity like a drama or chess club that involves no athletic activities.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether cheerleading is considered a sport or treated as a club activity like a drama or chess club that involves no athletic activities"
+    },
+    "469": {
+        "sentence": "It seems to be random whether these questions are relatively easy or impossibly difficult.",
+        "predicate": [
+            {
+                "str": "be",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "random",
+                "lemma": "random",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether these questions are relatively easy or impossibly difficult"
+    },
+    "470": {
+        "sentence": "You have to wonder whether the propaganda agenda is purely journalistic, or partly stems from NASA itself, since they felt it worthwhile issuing a sanely scientific rebuttal of \u2026 a couple of YouTube rumours based on \u201cvague sources\u201d.",
+        "predicate": [
+            {
+                "str": "wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the propaganda agenda is purely journalistic, or partly stems from NASA itself"
+    },
+    "471": {
+        "sentence": "It is unclear to us whether the word \"new\" in this measure applies only to MOUs or whether it also applies to other pension contracts or agreements, such as those delineated in statute or those applicable to managers and supervisors.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "unclear",
+                "lemma": "unclear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the word \"new\" in this measure applies only to MOUs or whether it also applies to other pension contracts or agreements, such as those delineated in statute or those applicable to managers and supervisors"
+    },
+    "472": {
+        "sentence": "The Trustees did not discuss whether the University should conduct an internal investigation to understand the facts and any potential liability issues, engage experience criminal counsel, or prepare for the possibility that the Grand Jury investigation might result in some criticism of the University or its staff.",
+        "predicate": [
+            {
+                "str": "discuss",
+                "lemma": "discuss",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the University should conduct an internal investigation to understand the facts and any potential liability issues, engage experience criminal counsel, or prepare for the possibility that the Grand Jury investigation might result in some criticism of the University or its staff"
+    },
+    "473": {
+        "sentence": "We do not see the profits of the elderly because it goes through the local administration, the District Commissioner and you wonder whether it got to the right people or whether it was eaten.",
+        "predicate": [
+            {
+                "str": "wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether it got to the right people or whether it was eaten"
+    },
+    "474": {
+        "sentence": "However it's not yet known whether these abnormalities are down to skin cancer or other causes.",
+        "predicate": [
+            {
+                "str": "known",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether these abnormalities are down to skin cancer or other causes"
+    },
+    "475": {
+        "sentence": "It will be irrelevant whether the target is considered a good or bad person.",
+        "predicate": [
+            {
+                "str": "be",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "irrelevant",
+                "lemma": "irrelevant",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the target is considered a good or bad person"
+    },
+    "476": {
+        "sentence": "It's hard to say whether DC will collect these Bill Willingham-written, Infinite Crisis-crossing stories, or whether they'll jump to the new material.",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether DC will collect these Bill Willingham-written, Infinite Crisis-crossing stories, or whether they'll jump to the new material"
+    },
+    "477": {
+        "sentence": "Here, Greenwood succinctly counters polarised ways of thinking in terms of \"primitive\" and \"modern,\" preferring instead to judge whether the significance of important past episodes \"represented an advance or regression in the general development of psychological theory and practice\" (4).",
+        "predicate": [
+            {
+                "str": "judge",
+                "lemma": "judge",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the significance of important past episodes \"represented an advance or regression in the general development of psychological theory and practice\" (4)"
+    },
+    "478": {
+        "sentence": "Julien Laurens is given the tough task of choosing whether Real Madrid or Barcelona should be considered La Liga favourites.",
+        "predicate": [
+            {
+                "str": "choosing",
+                "lemma": "choose",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Real Madrid or Barcelona should be considered La Liga favourites"
+    },
+    "479": {
+        "sentence": "The point is that this makes it possible to readily construct a relatively simple reader which can discern (by determining the length of the respective distance a or b) whether the carrier body 10 has been inserted with the edge 13 leading or with the edge 12 leading.",
+        "predicate": [
+            {
+                "str": "discern",
+                "lemma": "discern",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the carrier body 10 has been inserted with the edge 13 leading or with the edge 12 leading"
+    },
+    "480": {
+        "sentence": "From our point of view it is immaterial whether the state law question as to its meaning was controverted or accepted.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "immaterial",
+                "lemma": "immaterial",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the state law question as to its meaning was controverted or accepted"
+    },
+    "481": {
+        "sentence": "That said, it matters little whether I am over-eating or under-eating.",
+        "predicate": [
+            {
+                "str": "matters",
+                "lemma": "matter",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether I am over-eating or under-eating"
+    },
+    "482": {
+        "sentence": "Wonder whether during this thirty or forty year period of the low-fat dogma, whether breastfeeding rates went up or down.",
+        "predicate": [
+            {
+                "str": "Wonder",
+                "lemma": "wonder",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether during this thirty or forty year period of the low-fat dogma, whether breastfeeding rates went up or down"
+    },
+    "483": {
+        "sentence": "It is not quite clear whether it concerns a direct investment of a company resident in those countries or whether it would also apply to foreign companies investing in Cura\u00e7ao through intermediary holdings in those countries.",
+        "predicate": [
+            {
+                "str": "is",
+                "lemma": "be",
+                "POS": "AUX"
+            },
+            {
+                "str": "clear",
+                "lemma": "clear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether it concerns a direct investment of a company resident in those countries or whether it would also apply to foreign companies investing in Cura\u00e7ao through intermediary holdings in those countries"
+    },
+    "484": {
+        "sentence": "Multiplayer will include objectives that will differ depending on whether a player has chosen to fight for the Allies or Axis.",
+        "predicate": [
+            {
+                "str": "depending",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether a player has chosen to fight for the Allies or Axis"
+    },
+    "485": {
+        "sentence": "[50] It remains unclear whether these sites are the remains of the Xia dynasty or of another culture from the same period.",
+        "predicate": [
+            {
+                "str": "remains",
+                "lemma": "remain",
+                "POS": "VERB"
+            },
+            {
+                "str": "unclear",
+                "lemma": "unclear",
+                "POS": "ADJ"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether these sites are the remains of the Xia dynasty or of another culture from the same period"
+    },
+    "486": {
+        "sentence": "I'd be very curious to know whether a reunification of Ireland - either as a single Republic or as part of the UK - is even imaginable or are the differences still so strong that it's unthinkable?",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether a reunification of Ireland - either as a single Republic or as part of the UK - is even imaginable or are the differences still so strong that it's unthinkable"
+    },
+    "487": {
+        "sentence": "It can also be hard to tell whether such injuries are serious or less serious.",
+        "predicate": [
+            {
+                "str": "tell",
+                "lemma": "tell",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether such injuries are serious or less serious"
+    },
+    "488": {
+        "sentence": "The library should not have to deal with training staff to discern whether patrons are students or adults who look like students.",
+        "predicate": [
+            {
+                "str": "discern",
+                "lemma": "discern",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether patrons are students or adults who look like students"
+    },
+    "489": {
+        "sentence": "It doesn\u0092t even matter whether any given piece of your writing is carefully polished already or just a new idea you dashed off on the train today \u0096 as long as it\u0092s readable and well enough developed that a critique might be helpful.",
+        "predicate": [
+            {
+                "str": "matter",
+                "lemma": "matter",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether any given piece of your writing is carefully polished already or just a new idea you dashed off on the train today"
+    },
+    "490": {
+        "sentence": "Before it can be decided, however, whether this would be a monarchy or a republic, it seems necessary to settle the meaning of those terms.",
+        "predicate": [
+            {
+                "str": "decided",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether this would be a monarchy or a republic"
+    },
+    "491": {
+        "sentence": "However, in his evidence in chief he did not speak to whether Mandy was seated or lying down when he was picked up.",
+        "predicate": [
+            {
+                "str": "speak",
+                "lemma": "speak",
+                "POS": "VERB"
+            },
+            {
+                "str": "to",
+                "lemma": "to",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Mandy was seated or lying down when he was picked up"
+    },
+    "492": {
+        "sentence": "This will enable the Court to conclude whether PC Mc Vane was acting in self-defence when he shot Mandy or whether he and PC Polius acted negligently or recklessly in handling the situation and Mandy.",
+        "predicate": [
+            {
+                "str": "conclude",
+                "lemma": "conclude",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether PC Mc Vane was acting in self-defence when he shot Mandy or whether he and PC Polius acted negligently or recklessly in handling the situation and Mandy"
+    },
+    "493": {
+        "sentence": "So whether or not we have to be singing in order to hear this, or whether it is just going to manifest, I really do not know, but glory to God.",
+        "predicate": [
+            {
+                "str": "know",
+                "lemma": "know",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether or not we have to be singing in order to hear this, or whether it is just going to manifest"
+    },
+    "494": {
+        "sentence": "The authors did not identify whether the subjects were stretching completely cold, or whether they had \u0093warmed up\u0094 in any way prior to the stretching episode, which is common practice.",
+        "predicate": [
+            {
+                "str": "identify",
+                "lemma": "identify",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the subjects were stretching completely cold, or whether they had \u0093warmed up\u0094 in any way prior to the stretching episode, which is common practice"
+    },
+    "495": {
+        "sentence": "The distance will be positive or negative depending on whether the point is outside or inside the circle, but this does not matter since the value is squared as part of the minimization process.",
+        "predicate": [
+            {
+                "str": "depending",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the point is outside or inside the circle"
+    },
+    "496": {
+        "sentence": "After spending some time debating over whether to remain true to their artistic vision or try to be more commercial, they decided it would be better to \"go down in flames\" than compromise their musical integrity.",
+        "predicate": [
+            {
+                "str": "debating",
+                "lemma": "debate",
+                "POS": "VERB"
+            },
+            {
+                "str": "over",
+                "lemma": "over",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to remain true to their artistic vision or try to be more commercial"
+    },
+    "497": {
+        "sentence": "After spending some time debating over whether to remain true to their artistic vision or try to be more commercial, they decided it would be better to \"go down in flames\" than compromise their musical integrity.",
+        "predicate": [
+            {
+                "str": "decided",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "it would be better to \"go down in flames\" than compromise their musical integrity"
+    },
+    "498": {
+        "sentence": "An officer has to decide whether to serve India after gaining experience or stay back.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to serve India after gaining experience or stay back"
+    },
+    "499": {
+        "sentence": "In the end, it\u0092s almost hard to say whether Days of Future Past is a step forward \u0096 or backward \u0096 for the X-Men.",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Days of Future Past is a step forward \u0096 or backward \u0096 for the X-Men"
+    },
+    "500": {
+        "sentence": "Somehow he found himself back in his body - he can\u0092t recall whether the water pushed him out or if somebody pulled him to safety \u0096 but he was never again the same person.",
+        "predicate": [
+            {
+                "str": "recall",
+                "lemma": "recall",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the water pushed him out or if somebody pulled him to safety"
+    },
+    "501": {
+        "sentence": "There are various types of creams and these are distinguished by their fat content and or whether they have been whipped or heat treated.",
+        "predicate": [
+            {
+                "str": "distinguished",
+                "lemma": "distinguish",
+                "POS": "VERB"
+            },
+            {
+                "str": "by",
+                "lemma": "by",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether they have been whipped or heat treated"
+    },
+    "502": {
+        "sentence": "This concerns whether they fall into tax class 1 (mostly applicable to unmarried residents) or tax class 2 (people who are married or in civil partnerships).",
+        "predicate": [
+            {
+                "str": "concerns",
+                "lemma": "concern",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether they fall into tax class 1 (mostly applicable to unmarried residents) or tax class 2 (people who are married or in civil partnerships)"
+    },
+    "503": {
+        "sentence": "LONDON (AP) \u0097 British Prime Minister Theresa May is hunkered down with close allies as she considers whether to give in to relentless pressure to resign, or fight on to save her Brexit plan and her premiership.",
+        "predicate": [
+            {
+                "str": "considers",
+                "lemma": "consider",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to give in to relentless pressure to resign, or fight on to save her Brexit plan and her premiership"
+    },
+    "504": {
+        "sentence": "You should check whether the doors are made of solid wood or metal.",
+        "predicate": [
+            {
+                "str": "check",
+                "lemma": "check",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the doors are made of solid wood or metal"
+    },
+    "505": {
+        "sentence": "I almost asked whether she\u0092d been stabbed in a literal or metaphorical Barcelona, but it sounded snide so I didn\u0092t say anything.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether she\u0092d been stabbed in a literal or metaphorical Barcelona"
+    },
+    "506": {
+        "sentence": "The other two cats stood poised nearby, as if undecided on whether to back up their fellow or choose the better part of valor.",
+        "predicate": [
+            {
+                "str": "undecided",
+                "lemma": "undecided",
+                "POS": "ADJ"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to back up their fellow or choose the better part of valor"
+    },
+    "507": {
+        "sentence": "CFIUS would have 30 days to decide whether to require a full formal filing or determine that no further action is necessary.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to require a full formal filing or determine that no further action is necessary"
+    },
+    "508": {
+        "sentence": "CFIUS would have 30 days to decide whether to require a full formal filing or determine that no further action is necessary.",
+        "predicate": [
+            {
+                "str": "determine",
+                "lemma": "determine",
+                "POS": "VERB"
+            }
+        ],
+        "type": "declarative",
+        "clause": "that no further action is necessary"
+    },
+    "509": {
+        "sentence": "It is difficult to predict whether the Supreme Court\u0092s grant of certiorari in Bilski signals an intent to significantly narrow or expand the scope of patent eligibility under 35 U.S.C.",
+        "predicate": [
+            {
+                "str": "predict",
+                "lemma": "predict",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the Supreme Court\u0092s grant of certiorari in Bilski signals an intent to significantly narrow or expand the scope of patent eligibility under 35 U.S.C."
+    },
+    "510": {
+        "sentence": "Additional studies are needed to clarify whether this effect is consequent to a structural modification of PrPC, or a dislodgment from natural interacting partners, or a modification of the membrane lipid architecture surrounding the protein.",
+        "predicate": [
+            {
+                "str": "clarify",
+                "lemma": "clarify",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether this effect is consequent to a structural modification of PrPC, or a dislodgment from natural interacting partners, or a modification of the membrane lipid architecture surrounding the protein"
+    },
+    "511": {
+        "sentence": "Deciding whether you should join a team or go at it alone will have a significant impact on your success.",
+        "predicate": [
+            {
+                "str": "Deciding",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether you should join a team or go at it alone"
+    },
+    "512": {
+        "sentence": "Sources do not say whether he worked for a shipping company or for a government agency, such as the Federal Maritime Commission or the New York Port Authority.",
+        "predicate": [
+            {
+                "str": "say",
+                "lemma": "say",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether he worked for a shipping company or for a government agency, such as the Federal Maritime Commission or the New York Port Authority"
+    },
+    "513": {
+        "sentence": "To find out whether Intertops is as strong as ever, or is beginning to show its age, check out the rest of our review.",
+        "predicate": [
+            {
+                "str": "find",
+                "lemma": "find",
+                "POS": "VERB"
+            },
+            {
+                "str": "out",
+                "lemma": "out",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Intertops is as strong as ever, or is beginning to show its age"
+    },
+    "514": {
+        "sentence": "The scope of processing personal data primarily depends on whether a user simply visits one of our websites, uses them as a registered user or is just registering.",
+        "predicate": [
+            {
+                "str": "depends",
+                "lemma": "depend",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether a user simply visits one of our websites, uses them as a registered user or is just registering"
+    },
+    "515": {
+        "sentence": "reCAPTCHA is designed to check whether data is entered on our websites by a human or by automated software, e.g.",
+        "predicate": [
+            {
+                "str": "check",
+                "lemma": "check",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether data is entered on our websites by a human or by automated software, e.g."
+    },
+    "516": {
+        "sentence": "So I called Steve Koepp, my old editor, who now supervises TIME books, and asked him whether, after nine years, TIME had run out of ways to exploit the TIME 100 or I had run out of ways to make fun of it.",
+        "predicate": [
+            {
+                "str": "asked",
+                "lemma": "ask",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether, after nine years, TIME had run out of ways to exploit the TIME 100 or I had run out of ways to make fun of it"
+    },
+    "517": {
+        "sentence": "We just have to guess whether the card on the card on the player or the banker who will be the winner, or the game ends in a tie.",
+        "predicate": [
+            {
+                "str": "guess",
+                "lemma": "guess",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether the card on the card on the player or the banker who will be the winner"
+    },
+    "518": {
+        "sentence": "For centuries Jewish villages had to decide whether to stay and hope to survive hard times, or whether to flee across rivers and borders with what they could carry.",
+        "predicate": [
+            {
+                "str": "decide",
+                "lemma": "decide",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether to stay and hope to survive hard times, or whether to flee across rivers and borders with what they could carry"
+    },
+    "519": {
+        "sentence": "You can\u0092t easily configure whether you want the video to be oriented horizontally (landscape) or vertically (portrait).",
+        "predicate": [
+            {
+                "str": "configure",
+                "lemma": "configure",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether you want the video to be oriented horizontally (landscape) or vertically (portrait)"
+    },
+    "520": {
+        "sentence": "This includes the rights to property, the ability to raise children, and whether you will pay or receive alimony.",
+        "predicate": [
+            {
+                "str": "includes",
+                "lemma": "include",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether you will pay or receive alimony"
+    },
+    "521": {
+        "sentence": "I've gone back and forth on whether Desire or BOTT is my favorite Dylan record (with Blonde on Blonde working it's way in there from time to time).",
+        "predicate": [
+            {
+                "str": "gone",
+                "lemma": "go",
+                "POS": "VERB"
+            },
+            {
+                "str": "on",
+                "lemma": "on",
+                "POS": "ADP"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Desire or BOTT is my favorite Dylan record"
+    },
+    "522": {
+        "sentence": "What difference does it make whether Jesus or the Holy Spirit lives in my heart?\u0094.",
+        "predicate": [
+            {
+                "str": "make",
+                "lemma": "make",
+                "POS": "VERB"
+            }
+        ],
+        "type": "alternative",
+        "clause": "whether Jesus or the Holy Spirit lives in my heart"
+    }
+}


### PR DESCRIPTION
I flattened the golden sets for evaluation by removing the nested/coordinated structure, making separate entries for each embedded clause, indexed across the whole set